### PR TITLE
Allow optional alternate webroot paths.

### DIFF
--- a/histomicsui/constants.py
+++ b/histomicsui/constants.py
@@ -11,6 +11,7 @@ SettingDefault.defaults[SettingKey.BRAND_NAME] = 'HistomicsUI'
 class PluginSettings(object):
     HUI_DEFAULT_DRAW_STYLES = 'histomicsui.default_draw_styles'
     HUI_WEBROOT_PATH = 'histomicsui.webroot_path'
+    HUI_ALTERNATE_WEBROOT_PATH = 'histomicsui.alternate_webroot_path'
     HUI_BRAND_NAME = 'histomicsui.brand_name'
     HUI_BRAND_COLOR = 'histomicsui.brand_color'
     HUI_BANNER_COLOR = 'histomicsui.banner_color'

--- a/tests/test_hui_rest.py
+++ b/tests/test_hui_rest.py
@@ -275,6 +275,18 @@ class TestHUIEndpoints(object):
                 '#777': 'be a hex color'
             },
             'good': {'#000000': '#000000'},
+        }, {
+            'key': PluginSettings.HUI_ALTERNATE_WEBROOT_PATH,
+            'initial': None,
+            'bad': {
+                'girder': 'not contain "girder"',
+                'girder,histomicstk': 'not contain "girder"'
+            },
+            'good': {
+                '': '',
+                'histomicstk': 'histomicstk',
+                'hui,histomicstk': 'hui,histomicstk'
+            },
         }]
         for setting in settings:
             key = setting['key']


### PR DESCRIPTION
Add a setting allowing a comma-separate list of alternate webroot paths.  This facilitates migrating to a new webroot path by allowing old paths to still work.

This will help resolve https://github.com/DigitalSlideArchive/digital_slide_archive/issues/70