### PR TITLE
Brand name update

### DIFF
--- a/histomicsui/rest/hui_resource.py
+++ b/histomicsui/rest/hui_resource.py
@@ -50,8 +50,7 @@ class HistomicsUIResource(Resource):
             PluginSettings.HUI_BRAND_NAME,
             PluginSettings.HUI_DEFAULT_DRAW_STYLES,
             PluginSettings.HUI_QUARANTINE_FOLDER,
-            PluginSettings.HUI_WEBROOT_PATH,
-
+            PluginSettings.HUI_WEBROOT_PATH
         ]
         result = {k: Setting().get(k) for k in keys}
         result[PluginSettings.HUI_QUARANTINE_FOLDER] = bool(

--- a/histomicsui/rest/hui_resource.py
+++ b/histomicsui/rest/hui_resource.py
@@ -50,6 +50,8 @@ class HistomicsUIResource(Resource):
             PluginSettings.HUI_BRAND_NAME,
             PluginSettings.HUI_DEFAULT_DRAW_STYLES,
             PluginSettings.HUI_QUARANTINE_FOLDER,
+            PluginSettings.HUI_WEBROOT_PATH,
+
         ]
         result = {k: Setting().get(k) for k in keys}
         result[PluginSettings.HUI_QUARANTINE_FOLDER] = bool(

--- a/histomicsui/web_client/package.json
+++ b/histomicsui/web_client/package.json
@@ -60,7 +60,7 @@
             "switch-colon-spacing": "error",
             "object-curly-spacing": "off",
             "import/exports-last": "error",
-            "promise/no-native": "off",
+            "promise/no-native": "error",
             "promise/no-return-in-finally": "error",
             "promise/no-return-wrap": "error",
             "no-var": "off"

--- a/histomicsui/web_client/package.json
+++ b/histomicsui/web_client/package.json
@@ -60,7 +60,7 @@
             "switch-colon-spacing": "error",
             "object-curly-spacing": "off",
             "import/exports-last": "error",
-            "promise/no-native": "error",
+            "promise/no-native": "off",
             "promise/no-return-in-finally": "error",
             "promise/no-return-wrap": "error",
             "no-var": "off"

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -8,6 +8,8 @@ import { restRequest } from '@girder/core/rest';
 import events from '@girder/core/events';
 import router from '@girder/core/router';
 
+import { HuiSettings } from '../utils';
+
 import ConfigViewTemplate from '../../templates/body/configView.pug';
 import '../../stylesheets/body/configView.styl';
 
@@ -38,7 +40,7 @@ var ConfigView = View.extend({
             this.$('#g-hui-banner-color').val(this.defaults['histomicsui.banner_color']);
         },
         'click #g-hui-cancel': function (event) {
-            router.navigate('plugins', {trigger: true});
+            router.navigate('plugins', { trigger: true });
         },
         'click .g-open-browser': '_openBrowser'
     },
@@ -101,7 +103,7 @@ var ConfigView = View.extend({
             restRequest({
                 url: `resource/${val.id}/path`,
                 method: 'GET',
-                data: {type: val.get('_modelType')}
+                data: { type: val.get('_modelType') }
             }).done((result) => {
                 // Only add the resource path if the value wasn't altered
                 if (this.$('#g-hui-quarantine-folder').val() === val.id) {
@@ -129,6 +131,7 @@ var ConfigView = View.extend({
             },
             error: null
         }).done(() => {
+            HuiSettings.clearSettingsCache();
             events.trigger('g:alert', {
                 icon: 'ok',
                 text: 'Settings saved.',

--- a/histomicsui/web_client/views/itemList.js
+++ b/histomicsui/web_client/views/itemList.js
@@ -6,6 +6,8 @@ import { restRequest } from '@girder/core/rest';
 import events from '@girder/core/events';
 import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
 
+import HuiSettings from './utils';
+
 import '../stylesheets/views/itemList.styl';
 
 wrap(ItemListWidget, 'render', function (render) {
@@ -44,7 +46,7 @@ wrap(ItemListWidget, 'render', function (render) {
             });
             root.trigger('g:changed');
             if (root.parentView && root.parentView.setCurrentModel && root.parentView.parentModel) {
-                root.parentView.setCurrentModel(root.parentView.parentModel, {setRoute: false});
+                root.parentView.setCurrentModel(root.parentView.parentModel, { setRoute: false });
             } else {
                 target.closest('.g-item-list-entry').remove();
             }
@@ -59,17 +61,9 @@ wrap(ItemListWidget, 'render', function (render) {
     }
 
     if (this.accessLevel >= AccessType.WRITE) {
-        if (!this._hui_settings) {
-            restRequest({
-                type: 'GET',
-                url: 'histomicsui/settings'
-            }).done((resp) => {
-                this._hui_settings = resp;
-                adjustView(this._hui_settings);
-            });
-        } else {
-            adjustView(this._hui_settings);
-        }
+        HuiSettings.getSettings().done((settings) => {
+            adjustView(settings);
+        });
         this.events['click .g-hui-quarantine'] = quarantine;
         this.delegateEvents();
     }

--- a/histomicsui/web_client/views/itemList.js
+++ b/histomicsui/web_client/views/itemList.js
@@ -6,7 +6,7 @@ import { restRequest } from '@girder/core/rest';
 import events from '@girder/core/events';
 import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
 
-import HuiSettings from './utils';
+import { HuiSettings } from './utils';
 
 import '../stylesheets/views/itemList.styl';
 
@@ -61,8 +61,9 @@ wrap(ItemListWidget, 'render', function (render) {
     }
 
     if (this.accessLevel >= AccessType.WRITE) {
-        HuiSettings.getSettings().done((settings) => {
+        HuiSettings.getSettings().then((settings) => {
             adjustView(settings);
+            return settings;
         });
         this.events['click .g-hui-quarantine'] = quarantine;
         this.delegateEvents();

--- a/histomicsui/web_client/views/itemPage.js
+++ b/histomicsui/web_client/views/itemPage.js
@@ -4,6 +4,7 @@ import events from '@girder/core/events';
 import ItemView from '@girder/core/views/body/ItemView';
 
 import '../stylesheets/views/itemList.styl';
+import { HuiSettings } from './utils';
 
 wrap(ItemView, 'render', function (render) {
     function quarantine(event) {
@@ -30,24 +31,30 @@ wrap(ItemView, 'render', function (render) {
         });
     }
 
-    this.once('g:rendered', function () {
-        if (this.$el.find('.g-edit-item[role="menuitem"]').length && !this.$el.find('.g-hui-quarantine-item[role="menuitem"]').length) {
-            this.$el.find('.g-edit-item[role="menuitem"]').parent('li').after(
-                '<li role="presentation"><a class="g-hui-quarantine-item" role="menuitem"><span>Q</span>Quarantine item</a></li>'
-            );
-        }
-        if (this.$el.find('.g-item-actions-menu').length && !this.$el.find('.g-hui-open-item[role="menuitem"]').length &&
-            this.model.attributes.largeImage) {
-            this.$el.find('.g-item-actions-menu').prepend(
-                `<li role="presentation">
-                <a class="g-hui-open-item" role="menuitem" href="/hui#?image=${this.model.id}" target="_blank">
-                    <i class="icon-link-ext"></i>Open in HistomicsUI
-                </a>
-            </li>`
-            );
-        }
-        this.events['click .g-hui-quarantine-item'] = quarantine;
-        this.delegateEvents();
+    HuiSettings.getSettings().then((settings) => {
+        const brandName = (settings['histomicsui.brand_name'] || '');
+        const webrootPath = (settings['histomicsui.webroot_path'] || '');
+        this.once('g:rendered', function () {
+            if (this.$el.find('.g-edit-item[role="menuitem"]').length && !this.$el.find('.g-hui-quarantine-item[role="menuitem"]').length) {
+                this.$el.find('.g-edit-item[role="menuitem"]').parent('li').after(
+                    '<li role="presentation"><a class="g-hui-quarantine-item" role="menuitem"><span>Q</span>Quarantine item</a></li>'
+                );
+            }
+            if (this.$el.find('.g-item-actions-menu').length && !this.$el.find('.g-hui-open-item[role="menuitem"]').length &&
+                this.model.attributes.largeImage) {
+                this.$el.find('.g-item-actions-menu').prepend(
+                    `<li role="presentation">
+                    <a class="g-hui-open-item" role="menuitem" href="${webrootPath}#?image=${this.model.id}" target="_blank">
+                        <i class="icon-link-ext"></i>Open in ${brandName}
+                    </a>
+                </li>`
+                );
+            }
+            this.events['click .g-hui-quarantine-item'] = quarantine;
+            this.delegateEvents();
+        });
+        return settings;
     });
+
     render.call(this);
 });

--- a/histomicsui/web_client/views/itemPage.js
+++ b/histomicsui/web_client/views/itemPage.js
@@ -3,8 +3,9 @@ import { restRequest } from '@girder/core/rest';
 import events from '@girder/core/events';
 import ItemView from '@girder/core/views/body/ItemView';
 
-import '../stylesheets/views/itemList.styl';
 import { HuiSettings } from './utils';
+
+import '../stylesheets/views/itemList.styl';
 
 wrap(ItemView, 'render', function (render) {
     function quarantine(event) {
@@ -55,6 +56,5 @@ wrap(ItemView, 'render', function (render) {
         });
         return settings;
     });
-
     render.call(this);
 });

--- a/histomicsui/web_client/views/itemPage.js
+++ b/histomicsui/web_client/views/itemPage.js
@@ -31,11 +31,10 @@ wrap(ItemView, 'render', function (render) {
             });
         });
     }
-
-    HuiSettings.getSettings().then((settings) => {
-        const brandName = (settings['histomicsui.brand_name'] || '');
-        const webrootPath = (settings['histomicsui.webroot_path'] || '');
-        this.once('g:rendered', function () {
+    this.once('g:rendered', function () {
+        HuiSettings.getSettings().then((settings) => {
+            const brandName = (settings['histomicsui.brand_name'] || '');
+            const webrootPath = (settings['histomicsui.webroot_path'] || '');
             if (this.$el.find('.g-edit-item[role="menuitem"]').length && !this.$el.find('.g-hui-quarantine-item[role="menuitem"]').length) {
                 this.$el.find('.g-edit-item[role="menuitem"]').parent('li').after(
                     '<li role="presentation"><a class="g-hui-quarantine-item" role="menuitem"><span>Q</span>Quarantine item</a></li>'
@@ -53,8 +52,8 @@ wrap(ItemView, 'render', function (render) {
             }
             this.events['click .g-hui-quarantine-item'] = quarantine;
             this.delegateEvents();
+            return settings;
         });
-        return settings;
     });
     render.call(this);
 });

--- a/histomicsui/web_client/views/utils.js
+++ b/histomicsui/web_client/views/utils.js
@@ -1,22 +1,21 @@
 import { restRequest } from '@girder/core/rest';
 
-// Utility items for HistomicUI views
+/* Utility items for HistomicUI views
+  In the future more utility classes/functions can be added for export
+*/
 class HuiSettings {
     static getSettings() {
-        return new Promise((resolve, reject) => {
-            if (!HuiSettings._hui_settings) {
-                restRequest({
-                    type: 'GET',
-                    url: 'histomicsui/settings'
-                }).then((resp) => {
-                    HuiSettings._hui_settings = resp;
-                    resolve(HuiSettings._hui_settings);
-                    return HuiSettings._hui_settings;
-                });
-            } else {
-                resolve(HuiSettings._hui_settings);
-            }
-        });
+        if (HuiSettings._hui_settings) {
+            return HuiSettings._hui_settings;
+        } else {
+            HuiSettings._hui_settings = restRequest({
+                type: 'GET',
+                url: 'histomicsui/settings'
+            }).then((resp) => {
+                return resp;
+            });
+        }
+        return HuiSettings._hui_settings;
     }
     static clearSettingsCache() {
         delete HuiSettings._hui_settings;
@@ -25,4 +24,4 @@ class HuiSettings {
 
 HuiSettings._hui_settings = null;
 
-export default HuiSettings;
+export { HuiSettings };

--- a/histomicsui/web_client/views/utils.js
+++ b/histomicsui/web_client/views/utils.js
@@ -1,0 +1,28 @@
+import { restRequest } from '@girder/core/rest';
+
+// Utility items for HistomicUI views
+class HuiSettings {
+    static getSettings() {
+        return new Promise((resolve, reject) => {
+            if (!HuiSettings._hui_settings) {
+                restRequest({
+                    type: 'GET',
+                    url: 'histomicsui/settings'
+                }).then((resp) => {
+                    HuiSettings._hui_settings = resp;
+                    resolve(HuiSettings._hui_settings);
+                    return HuiSettings._hui_settings;
+                });
+            } else {
+                resolve(HuiSettings._hui_settings);
+            }
+        });
+    }
+    static clearSettingsCache() {
+        delete HuiSettings._hui_settings;
+    }
+}
+
+HuiSettings._hui_settings = null;
+
+export default HuiSettings;

--- a/histomicsui/web_client/views/utils.js
+++ b/histomicsui/web_client/views/utils.js
@@ -4,6 +4,10 @@ import { restRequest } from '@girder/core/rest';
   In the future more utility classes/functions can be added for export
 */
 class HuiSettings {
+    constructor() {
+        HuiSettings._hui_settings = null;
+    }
+
     static getSettings() {
         if (HuiSettings._hui_settings) {
             return HuiSettings._hui_settings;
@@ -17,11 +21,10 @@ class HuiSettings {
         }
         return HuiSettings._hui_settings;
     }
+
     static clearSettingsCache() {
         delete HuiSettings._hui_settings;
     }
 }
-
-HuiSettings._hui_settings = null;
 
 export { HuiSettings };

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -147,6 +147,7 @@ def testWebClientWithWorker(boundServer, fsAssetstore, db, admin, user, spec, gi
     'annotationSpec.js',
     'huiSpec.js',
     'girderUISpec.js',
+    'itemSpec.js'
 ))
 def testWebClient(boundServer, fsAssetstore, db, admin, user, spec):
     copyHUITest()

--- a/tests/web_client_specs/girderUISpec.js
+++ b/tests/web_client_specs/girderUISpec.js
@@ -40,10 +40,7 @@ describe('itemList', function () {
         girderTest.waitForLoad();
         waitsFor(function () {
             return $('.g-item-actions-button').length > 0;
-        });
-        runs(function () {
-            $('.g-item-actions-button').parent().addClass('group');
-        });
+        });        
     });
     it('has a Open HistomicsUI button', function () {
         runs(function () {

--- a/tests/web_client_specs/itemSpec.js
+++ b/tests/web_client_specs/itemSpec.js
@@ -51,7 +51,7 @@ describe('Test the HistomicsUI itemUI screen', function () {
             var settingsBrandName = (settings && settings['histomicsui.brand_name']);
             var settingsWebRootPath = (settings && settings['histomicsui.webroot_path']);
 
-            return (settingsBrandName && settingsBrandName === brandName && settingsWebRootPath && settingsWebRootPath === webRootPath);
+            return (settingsBrandName === brandName && settingsWebRootPath === webRootPath);
         }, 'HistomicsUI settings to change');
     });
     it('mock Webgl', function () {

--- a/tests/web_client_specs/itemSpec.js
+++ b/tests/web_client_specs/itemSpec.js
@@ -51,7 +51,7 @@ describe('Test the HistomicsUI itemUI screen', function () {
             var settingsBrandName = (settings && settings['histomicsui.brand_name']);
             var settingsWebRootPath = (settings && settings['histomicsui.webroot_path']);
 
-            return (settingsBrandName === brandName && settingsWebRootPath === webRootPath);
+            return settingsBrandName === brandName && settingsWebRootPath === webRootPath;
         }, 'HistomicsUI settings to change');
     });
     it('mock Webgl', function () {

--- a/tests/web_client_specs/itemSpec.js
+++ b/tests/web_client_specs/itemSpec.js
@@ -1,0 +1,122 @@
+/* globals girder, girderTest, describe, it, expect, waitsFor, runs */
+
+girderTest.importPlugin('jobs', 'worker', 'large_image', 'large_image_annotation', 'slicer_cli_web', 'histomicsui');
+
+girderTest.startApp();
+
+describe('Test the HistomicsUI itemUI screen', function () {
+    var brandName = 'TestBrandName';
+    var webRootPath = 'TestRootPath';
+
+    it('login', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'password')();
+    });
+    it('change the HistomicsUI settings', function () {
+        waitsFor(function () {
+            return $('a.g-nav-link[g-target="admin"]').length > 0;
+        }, 'admin console link to load');
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-plugins-config').length > 0;
+        }, 'the admin console to load');
+        runs(function () {
+            $('.g-plugins-config').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-plugin-config-link').length > 0;
+        }, 'the plugins page to load');
+        runs(function () {
+            expect($('.g-plugin-config-link[g-route="plugins/histomicsui/config"]').length > 0);
+            $('.g-plugin-config-link[g-route="plugins/histomicsui/config"]').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('#g-hui-form input').length > 0;
+        }, 'settings to be shown');
+        runs(function () {
+            $('#g-hui-webroot-path').val(webRootPath);
+            $('#g-hui-brand-name').val(brandName);
+            $('.g-hui-buttons .btn-primary').click();
+        });
+        waitsFor(function () {
+            var resp = girder.rest.restRequest({
+                url: 'histomicsui/settings',
+                method: 'GET',
+                async: false
+            });
+            var settings = resp.responseJSON;
+            var settingsBrandName = (settings && settings['histomicsui.brand_name']);
+            var settingsWebRootPath = (settings && settings['histomicsui.webroot_path']);
+
+            return (settingsBrandName && settingsBrandName === brandName && settingsWebRootPath && settingsWebRootPath === webRootPath);
+        }, 'HistomicsUI settings to change');
+    });
+
+    it('mock Webgl', function () {
+        var GeojsViewer = window.girder.plugins.large_image.views.imageViewerWidget.geojs;
+        window.girder.utilities.PluginUtils.wrap(GeojsViewer, 'initialize', function (initialize) {
+            this.once('g:beforeFirstRender', function () {
+                window.geo.util.mockWebglRenderer();
+            });
+            initialize.apply(this, _.rest(arguments));
+        });
+    });
+    it('go to user item', function () {
+        runs(function () {
+            $("a.g-nav-link[g-target='users']").click();
+        });
+        waitsFor(function () {
+            return $('a.g-user-link').length > 0;
+        });
+        runs(function () {
+            $('a.g-user-link').last().click();
+        });
+        waitsFor(function () {
+            return $('a.g-folder-list-link').length > 0;
+        });
+        runs(function () {
+            $('.g-folder-list-link:contains("Public")').click();
+        });
+        waitsFor(function () {
+            return $('a.g-item-list-link:contains("image")').length > 0;
+        });
+        runs(function () {
+            $('a.g-item-list-link:contains("image")').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-item-actions-button').length > 0;
+        });
+        runs(function () {
+            $('.g-item-actions-button').click();
+        });
+        waitsFor(function () {
+            return $('.g-item-actions-menu').is(':visible');
+        });
+        girderTest.waitForLoad();
+    });
+    // Lets check to see if there are the proper ui elements
+    it('taking screenshot', function () {
+        waits(1500);
+        console.log('__SCREENSHOT__FINAL');
+    });
+
+    it('has a Open HistomicsUI button with TestBrandName', function () {
+        runs(function () {
+            expect($('.g-hui-open-item').text().indexOf(brandName) !== -1).toBe(true);
+        });
+    });
+    it('has a Open HistomicsUI button with link to webRootPath', function () {
+        runs(function () {
+            expect($('.g-hui-open-item').attr('href').indexOf(webRootPath) !== -1).toBe(true);
+        });
+    });
+    it('has a Quarantine Item button', function () {
+        runs(function () {
+            expect($('.g-hui-quarantine-item').length).toBe(1);
+        });
+    });
+});

--- a/tests/web_client_specs/itemSpec.js
+++ b/tests/web_client_specs/itemSpec.js
@@ -54,7 +54,6 @@ describe('Test the HistomicsUI itemUI screen', function () {
             return (settingsBrandName && settingsBrandName === brandName && settingsWebRootPath && settingsWebRootPath === webRootPath);
         }, 'HistomicsUI settings to change');
     });
-
     it('mock Webgl', function () {
         var GeojsViewer = window.girder.plugins.large_image.views.imageViewerWidget.geojs;
         window.girder.utilities.PluginUtils.wrap(GeojsViewer, 'initialize', function (initialize) {
@@ -98,12 +97,6 @@ describe('Test the HistomicsUI itemUI screen', function () {
         });
         girderTest.waitForLoad();
     });
-    // Lets check to see if there are the proper ui elements
-    it('taking screenshot', function () {
-        waits(1500);
-        console.log('__SCREENSHOT__FINAL');
-    });
-
     it('has a Open HistomicsUI button with TestBrandName', function () {
         runs(function () {
             expect($('.g-hui-open-item').text().indexOf(brandName) !== -1).toBe(true);


### PR DESCRIPTION
Updated the BrandName display in the item view (Open in {BrandName}) to reflect brand name set in the plugin settings.  Updated link to go to the correct webroot_path also set in the plugin settings.  These settings are now public settings that are accessible through the histomicsui/settings endpoint.

Add a utils.js to the views with a single HUISettings tool for caching settings.  Used a name export for any needed future utilities.

Added an additional itemSpec test, to change the webroot_path and brandname and confirm the changes in the itemview.  This may overlap the girderUISpec.js test which confirms that an Open in HistomicsUI button and the quarantine button exist.  So it can possibly be rolled into one test in the future.