### PR TITLE
Fix showing double quarantine buttons.

### DIFF
--- a/histomicsui/web_client/views/itemList.js
+++ b/histomicsui/web_client/views/itemList.js
@@ -21,7 +21,7 @@ wrap(ItemListWidget, 'render', function (render) {
         }
         root.$el.find('.g-item-list-entry').each(function () {
             var parent = $(this);
-            parent.remove('.g-hui-quarantine');
+            parent.find('.g-hui-quarantine').remove();
             parent.append($('<a class="g-hui-quarantine"><span>Q</span></a>').attr({
                 'g-item-cid': $('[g-item-cid]', parent).attr('g-item-cid'),
                 title: 'Move this item to the quarantine folder'


### PR DESCRIPTION
Some code to prevent double quarantine buttons wasn't working.

It would probably be better not to do a remove-and-reinsert, but this is a minimal change.