### PR TITLE
Start at the last image in the browser widget.

### DIFF
--- a/histomicsui/web_client/dialogs/openAnnotatedImage.js
+++ b/histomicsui/web_client/dialogs/openAnnotatedImage.js
@@ -58,7 +58,7 @@ const OpenAnnotatedImage = View.extend({
 
         this._users = new UserCollection();
         this._users.sortField = 'login';
-        this._users.pageLimit = 500;
+        this._users.pageLimit = 0;
         this._usersIsFetched = false;
         this._users.fetch().done(() => {
             this._usersIsFetched = true;

--- a/histomicsui/web_client/dialogs/openImage.js
+++ b/histomicsui/web_client/dialogs/openImage.js
@@ -20,7 +20,7 @@ function createDialog(item, itemParent) {
         root: itemParent,
         rootSelectorSettings: {
             pageLimit: 0,
-            selectByResource: itemParent ? itemParent.get('baseParentId') : undefined
+            selectByResource: itemParent
         },
         validate: function (item) {
             if (!item.has('largeImage')) {

--- a/histomicsui/web_client/dialogs/openImage.js
+++ b/histomicsui/web_client/dialogs/openImage.js
@@ -1,13 +1,15 @@
 import $ from 'jquery';
 
 import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
+import ItemModel from '@girder/core/models/ItemModel';
+import FolderModel from '@girder/core/models/FolderModel';
 
 import events from '../events';
 import router from '../router';
 
 var dialog;
 
-function createDialog() {
+function createDialog(item, itemParent) {
     var widget = new BrowserWidget({
         parentView: null,
         titleText: 'Select a slide...',
@@ -15,15 +17,20 @@ function createDialog() {
         showItems: true,
         selectItem: true,
         helpText: 'Click on a slide item to open.',
+        root: itemParent,
         rootSelectorSettings: {
-            pageLimit: 50
+            pageLimit: 0,
+            selectByResource: itemParent ? itemParent.get('baseParentId') : undefined
         },
         validate: function (item) {
             if (!item.has('largeImage')) {
                 return $.Deferred().reject('Please select a "large image" item.').promise();
             }
             return $.Deferred().resolve().promise();
-        }
+        },
+        highlightItem: true,
+        paginated: true,
+        defaultSelectedResource: item
     });
     widget.on('g:saved', (model) => {
         if (!model) {
@@ -44,8 +51,26 @@ function createDialog() {
 }
 
 events.on('h:openImageUi', function () {
-    if (!dialog) {
-        dialog = createDialog();
+    var itemId = router.getQuery('image');
+    if (itemId) {
+        var item = new ItemModel();
+        item.set({ _id: router.getQuery('image') }).once('g:fetched', () => {
+            if (router.getQuery('folder')) {
+                var folder = new FolderModel();
+                var folderId = router.getQuery('folder');
+                folder.set({ _id: folderId }).once('g:fetched', () => {
+                    dialog = createDialog(item, folder);
+                    dialog.setElement($('#g-dialog-container')).render();
+                }).fetch();
+            } else {
+                dialog = createDialog(item);
+                dialog.setElement($('#g-dialog-container')).render();
+            }
+        }).fetch();
+    } else {
+        if (!dialog) {
+            dialog = createDialog();
+        }
+        dialog.setElement($('#g-dialog-container')).render();
     }
-    dialog.setElement($('#g-dialog-container')).render();
 });


### PR DESCRIPTION
This uses new browser widget features and works with virtual folders.

This also gets all users and root items, rather than an arbitrary number.  When there are more users or root items than the arbitrary limit, there was no indication that not all items were loaded.  Here, an excessive number of users or collections could break the UI, but this is unlikely to happen and would at least be an obvious problem instead of appearing to have missing data.