### PR TITLE
Show area on annotation popover.

### DIFF
--- a/histomicsui/web_client/dialogs/editStyleGroups.js
+++ b/histomicsui/web_client/dialogs/editStyleGroups.js
@@ -94,7 +94,6 @@ const EditStyleGroups = View.extend({
                 .removeClass('hidden');
         }
 
-        console.log(JSON.stringify(data)); // DWM::
         this.model.set(data);
     },
 


### PR DESCRIPTION
This also shows perimeter of polygons and lengths of line annotations.  Most values are shown in both pixels and SI units.
![image](https://user-images.githubusercontent.com/8781639/83797727-11e5a780-a671-11ea-918e-4bcabc16189e.png)
![image](https://user-images.githubusercontent.com/8781639/83797770-2033c380-a671-11ea-9ba1-26ea396c96c1.png)
![image](https://user-images.githubusercontent.com/8781639/83797840-3b9ece80-a671-11ea-9c05-d96b02384163.png)

