### PR TITLE
Support a panel layout setting.

### DIFF
--- a/histomicsui/__init__.py
+++ b/histomicsui/__init__.py
@@ -90,7 +90,8 @@ def patchCookieParsing():
 
 
 @setting_utilities.validator({
-    PluginSettings.HUI_DEFAULT_DRAW_STYLES
+    PluginSettings.HUI_DEFAULT_DRAW_STYLES,
+    PluginSettings.HUI_PANEL_LAYOUT,
 })
 def validateListOrJSON(doc):
     val = doc['value']

--- a/histomicsui/constants.py
+++ b/histomicsui/constants.py
@@ -10,6 +10,7 @@ SettingDefault.defaults[SettingKey.BRAND_NAME] = 'HistomicsUI'
 # Constants representing the setting keys for this plugin
 class PluginSettings(object):
     HUI_DEFAULT_DRAW_STYLES = 'histomicsui.default_draw_styles'
+    HUI_PANEL_LAYOUT = 'histomicsui.panel_layout'
     HUI_WEBROOT_PATH = 'histomicsui.webroot_path'
     HUI_ALTERNATE_WEBROOT_PATH = 'histomicsui.alternate_webroot_path'
     HUI_BRAND_NAME = 'histomicsui.brand_name'

--- a/histomicsui/rest/hui_resource.py
+++ b/histomicsui/rest/hui_resource.py
@@ -47,6 +47,7 @@ class HistomicsUIResource(Resource):
         keys = [
             PluginSettings.HUI_BRAND_NAME,
             PluginSettings.HUI_DEFAULT_DRAW_STYLES,
+            PluginSettings.HUI_PANEL_LAYOUT,
             PluginSettings.HUI_QUARANTINE_FOLDER,
             PluginSettings.HUI_WEBROOT_PATH
         ]

--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -90,9 +90,9 @@ var AnnotationSelector = Panel.extend({
                     interactiveMode: this._interactiveMode,
                     expandedGroups: this._expandedGroups,
                     annotationGroups,
+                    collapsed: this.$('.s-panel-content.collapse').length && !this.$('.s-panel-content').hasClass('in'),
                     _
                 }));
-                this.$('.s-panel-content').collapse({toggle: false});
                 this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
                 this._changeGlobalOpacity();
                 this._changeGlobalFillOpacity();

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -88,14 +88,14 @@ var DrawWidget = Panel.extend({
                 groups: this._groups,
                 style: this._style.id,
                 highlighted: this._highlighted,
-                name
+                name,
+                collapsed: this.$('.s-panel-content.collapse').length && !this.$('.s-panel-content').hasClass('in')
             }));
         }
         if (this._drawingType) {
             this.$('button.h-draw[data-type="' + this._drawingType + '"]').addClass('active');
             this.drawElement(undefined, this._drawingType);
         }
-        this.$('.s-panel-content').collapse({toggle: false});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
         if (this.viewer.annotationLayer && !this.viewer.annotationLayer._boundHUIModeChange) {
             this.viewer.annotationLayer._boundHUIModeChange = true;

--- a/histomicsui/web_client/panels/MetadataWidget.js
+++ b/histomicsui/web_client/panels/MetadataWidget.js
@@ -496,7 +496,7 @@ var MetadataWidget = Panel.extend({
                     accessLevel: this.item.attributes._accessLevel,
                     AccessType: AccessType,
                     // if never rendered, the jquery selector will be empty and won't be visible
-                    collapsed: !this.$('.s-panel-content').is(':visible')
+                    collapsed: !this.$('.s-panel-content').hasClass('in')
                 }));
                 // Append each metadatum
                 _.each(metaKeys, function (metaKey) {
@@ -512,8 +512,6 @@ var MetadataWidget = Panel.extend({
                         onMetadataAdded: this.onMetadataAdded
                     }).render().$el);
                 }, this);
-                // by default the widget should be collapsed
-                this.$('.s-panel-content').collapse({toggle: false});
             });
         }
         return this;

--- a/histomicsui/web_client/panels/ZoomWidget.js
+++ b/histomicsui/web_client/panels/ZoomWidget.js
@@ -83,14 +83,12 @@ var ZoomWidget = Panel.extend({
             step: step,
             value: Math.log2(value) - Math.log2(this._maxMag),
             disabled: !this.renderer,
-            buttons: buttons
+            buttons: buttons,
+            collapsed: this.$('.s-panel-content.collapse').length && !this.$('.s-panel-content').hasClass('in')
         }));
 
         // enable or disable zoom range buttons
         this._zoomRangeControls();
-
-        // make the panel collapsible
-        this.$('.s-panel-content').collapse({toggle: false});
 
         // show tooltip of different download button
         this.$('[data-toggle="tooltip"]').tooltip();

--- a/histomicsui/web_client/stylesheets/body/image.styl
+++ b/histomicsui/web_client/stylesheets/body/image.styl
@@ -22,23 +22,33 @@
       padding 0 3px
       border-radius 3px
 
-  .h-control-panel-container
-
+  .h-panel-group-left
     overflow-y auto
+    width 300px
+    margin-left 0
+
+    .s-panel
+      margin-left 5px
 
     .h-control-panel.s-panel-group
       background-color rgba(255, 255, 255, 0.5)
       border 1px solid black
       border-radius 5px
 
-  #h-annotation-selector-container
-    right 0
+  .h-panel-group-right
     overflow-y auto
     width 300px
+    right 0
 
     .s-panel
       margin-right 5px
 
 #h-annotation-context-menu
-    position absolute
-    z-index 1000
+  position absolute
+  z-index 1000
+
+.s-panel-group .s-panel:empty
+  border none
+
+.geojs-map
+  outline none

--- a/histomicsui/web_client/templates/body/configView.pug
+++ b/histomicsui/web_client/templates/body/configView.pug
@@ -36,7 +36,14 @@ form#g-hui-form(role="form")
     input#g-hui-default-draw-styles.input-sm.form-control(
         type="text", value=settings['histomicsui.default_draw_styles'],
         placeholder='A JSON object listing default annotation drawing styles.',
-        title='A dictionary of drawing styles')
+        title='A list of dictionaries of drawing styles')
+  .form-group
+    label
+      | Panel layout
+    input#g-hui-panel-layout.input-sm.form-control(
+        type="text", value=settings['histomicsui.panel_layout'],
+        placeholder='A JSON list of objects for each panel',
+        title='A JSON list of objects for each panel.  Each panel has name (the short internal name, such as zoom, draw, or analysis), position (one of default, left, right, hidden), state (one of default, open, closed)')
   .form-group
     label(for="g-hui-quarantine-folder") Quarantine Folder
     p.g-hui-description

--- a/histomicsui/web_client/templates/body/image.pug
+++ b/histomicsui/web_client/templates/body/image.pug
@@ -4,11 +4,12 @@
     .h-image-coordinates-container.hidden
       span.icon-location
       span.h-image-coordinates 0, 0
-  .h-control-panel-container.s-panel-group
-  #h-annotation-selector-container.s-panel-group.hidden
-    .h-zoom-widget.s-panel
-    .h-metadata-widget.s-panel
-    .h-annotation-selector.s-panel
-    .h-draw-widget.s-panel.hidden
+  .h-control-panel-container.s-panel-group.h-panel-group-left
+    #h-analysis-panel
+  #h-annotation-selector-container.s-panel-group.h-panel-group-right
+    #h-zoom-panel.h-zoom-widget.s-panel
+    #h-metadata-panel.h-metadata-widget.s-panel
+    #h-annotation-panel.h-annotation-selector.s-panel
+    #h-draw-panel.h-draw-widget.s-panel.hidden
   #h-annotation-popover-container
   #h-annotation-context-menu.hidden

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -56,6 +56,7 @@ var ConfigView = View.extend({
             'histomicsui.brand_color',
             'histomicsui.banner_color',
             'histomicsui.default_draw_styles',
+            'histomicsui.panel_layout',
             'histomicsui.quarantine_folder'
         ];
         $.when(

--- a/histomicsui/web_client/views/utils.js
+++ b/histomicsui/web_client/views/utils.js
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 import { restRequest } from '@girder/core/rest';
 
 /* Utility items for HistomicUI views
@@ -10,12 +12,16 @@ class HuiSettings {
 
     static getSettings() {
         if (HuiSettings._hui_settings) {
+            if (HuiSettings._hui_settings_result) {
+                return HuiSettings._hui_settings_result;
+            }
             return HuiSettings._hui_settings;
         } else {
             HuiSettings._hui_settings = restRequest({
                 type: 'GET',
                 url: 'histomicsui/settings'
             }).then((resp) => {
+                HuiSettings._hui_settings = $.Deferred().resolve(resp);
                 return resp;
             });
         }

--- a/tests/test_hui_rest.py
+++ b/tests/test_hui_rest.py
@@ -232,30 +232,32 @@ class TestHUIEndpoints(object):
         Group().addUser(self.group, self.user2)
 
     def testHUISettings(self, server):
-        key = PluginSettings.HUI_DEFAULT_DRAW_STYLES
+        for key in {
+                PluginSettings.HUI_DEFAULT_DRAW_STYLES,
+                PluginSettings.HUI_PANEL_LAYOUT}:
 
-        resp = server.request(path='/histomicsui/settings')
-        assert utilities.respStatus(resp) == 200
-        settings = resp.json
-        assert settings[key] is None
-        assert settings[PluginSettings.HUI_BRAND_NAME] == 'HistomicsUI'
+            resp = server.request(path='/histomicsui/settings')
+            assert utilities.respStatus(resp) == 200
+            settings = resp.json
+            assert settings[key] is None
+            assert settings[PluginSettings.HUI_BRAND_NAME] == 'HistomicsUI'
 
-        Setting().set(key, '')
-        assert Setting().get(key) is None
-        with pytest.raises(ValidationException, match='must be a JSON'):
-            Setting().set(key, 'not valid')
-        with pytest.raises(ValidationException, match='must be a JSON'):
-            Setting().set(key, json.dumps({'not': 'a list'}))
-        value = [{'lineWidth': 8, 'id': 'Group 8'}]
-        Setting().set(key, json.dumps(value))
-        assert json.loads(Setting().get(key)) == value
-        Setting().set(key, value)
-        assert json.loads(Setting().get(key)) == value
+            Setting().set(key, '')
+            assert Setting().get(key) is None
+            with pytest.raises(ValidationException, match='must be a JSON'):
+                Setting().set(key, 'not valid')
+            with pytest.raises(ValidationException, match='must be a JSON'):
+                Setting().set(key, json.dumps({'not': 'a list'}))
+            value = [{'lineWidth': 8, 'id': 'Group 8'}]
+            Setting().set(key, json.dumps(value))
+            assert json.loads(Setting().get(key)) == value
+            Setting().set(key, value)
+            assert json.loads(Setting().get(key)) == value
 
-        resp = server.request(path='/histomicsui/settings')
-        assert utilities.respStatus(resp) == 200
-        settings = resp.json
-        assert json.loads(settings[key]) == value
+            resp = server.request(path='/histomicsui/settings')
+            assert utilities.respStatus(resp) == 200
+            settings = resp.json
+            assert json.loads(settings[key]) == value
 
     def testGeneralSettings(self, server, admin, user):
         self.makeResources(admin)

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -147,7 +147,8 @@ def testWebClientWithWorker(boundServer, fsAssetstore, db, admin, user, spec, gi
     'annotationSpec.js',
     'huiSpec.js',
     'girderUISpec.js',
-    'itemSpec.js'
+    'itemSpec.js',
+    'panelLayoutSpec.js',
 ))
 def testWebClient(boundServer, fsAssetstore, db, admin, user, spec):
     copyHUITest()

--- a/tests/web_client_specs/panelLayoutSpec.js
+++ b/tests/web_client_specs/panelLayoutSpec.js
@@ -1,0 +1,72 @@
+/* global huiTest */
+
+girderTest.importPlugin('jobs', 'worker', 'large_image', 'large_image_annotation', 'slicer_cli_web', 'histomicsui');
+girderTest.addScript('/static/built/plugins/histomicsui/huiTest.js');
+
+girderTest.promise.done(function () {
+    huiTest.startApp();
+
+    describe('Panel layout tests', function () {
+        describe('setup', function () {
+            it('login', function () {
+                huiTest.login('admin', 'password');
+            });
+
+            it('change settings', function () {
+                runs(function () {
+                    girder.rest.restRequest({
+                        url: '/system/setting',
+                        method: 'PUT',
+                        data: {
+                            key: 'histomicsui.panel_layout',
+                            value: JSON.stringify([{
+                                name: 'annotation',
+                                state: 'closed'
+                            }, {
+                                name: 'metadata'
+                            }, {
+                                name: 'zoom',
+                                position: 'left'
+                            }])
+                        },
+                        async: false
+                    });
+                });
+            });
+            it('logout admin', girderTest.logout());
+            it('login regular user', function () {
+                huiTest.login();
+            });
+            it('open image', function () {
+                huiTest.openImage('image');
+            });
+        });
+
+        describe('Check panel locations', function () {
+            it('check locations', function () {
+                runs(function () {
+                    var left = $('.h-panel-group-left [id^=h-][id$=-panel]');
+                    var leftIds = left.map(function (idx, panel) {
+                        return $(panel).attr('id');
+                    });
+                    expect(leftIds.toArray()).toEqual(['h-zoom-panel', 'h-analysis-panel']);
+
+                    var right = $('.h-panel-group-right [id^=h-][id$=-panel]');
+                    var rightIds = right.map(function (idx, panel) {
+                        return $(panel).attr('id');
+                    });
+                    expect(rightIds.toArray()).toEqual(['h-annotation-panel', 'h-metadata-panel', 'h-draw-panel']);
+                });
+                waitsFor(function () {
+                    return !$('#h-annotation-panel .s-panel-content').hasClass('in');
+                }, 'panel to close');
+                runs(function () {
+                    expect($('#h-annotation-panel .s-panel-content').hasClass('in')).toBe(false);
+                });
+                runs(function () {
+                    expect($('#h-zoom-panel .s-panel-content').hasClass('in')).toBe(true);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
This adds a setting which takes a json list.  Each entry in the list consists of a dictionary with the name of a panel (using short internal names), and, optional position and state.  The title (tooltip) text on the setting lists the options.