### PR TITLE
Add an image overview panel.

### DIFF
--- a/histomicsui/web_client/panels/OverviewWidget.js
+++ b/histomicsui/web_client/panels/OverviewWidget.js
@@ -1,0 +1,156 @@
+/* global geo */
+import _ from 'underscore';
+
+import Panel from '@girder/slicer_cli_web/views/Panel';
+
+import overviewWidget from '../templates/panels/overviewWidget.pug';
+import '../stylesheets/panels/overviewWidget.styl';
+
+var OverviewWidget = Panel.extend({
+    render() {
+        this.$el.html(overviewWidget({
+            id: 'overview-panel-container',
+            collapsed: this.$('.s-panel-content.collapse').length && !this.$('.s-panel-content').hasClass('in')
+        }));
+        window.setTimeout(() => {
+            this._createOverview();
+        }, 1);
+        return this;
+    },
+
+    /**
+     * Set the viewer instance and set several internal variables used
+     * to convert between magnification and zoom level.
+     */
+    setViewer(viewer) {
+        if (viewer !== this.parentViewer) {
+            if (this.parentViewer && this.parentViewer.viewer && this._boundOnParentPan) {
+                this.parentViewer.viewer.geoOff(geo.event.pan, this._boundOnParentPan);
+                this._boundOnParentPan = null;
+            }
+            this.parentViewer = viewer;
+            this._createOverview();
+        }
+        return this;
+    },
+
+    setImage(tiles) {
+        this._tiles = tiles;
+        this._createOverview();
+        return this;
+    },
+
+    _createOverview() {
+        if (!this._tiles || !this.parentViewer || !this.parentViewer.viewer || !this.$el.find('.h-overview-image').length) {
+            if (this.viewer) {
+                this.viewer.exit();
+                this.viewer = null;
+            }
+            return;
+        }
+        let tiles = this._tiles;
+
+        let params = geo.util.pixelCoordinateParams(
+            this.$el.find('.h-overview-image'), tiles.sizeX, tiles.sizeY, tiles.tileWidth, tiles.tileHeight);
+        params.layer.useCredentials = true;
+        params.layer.url = this.parentViewer._getTileUrl('{z}', '{x}', '{y}');
+        if (tiles.tileWidth > 8192 || tiles.tileHeight > 8192) {
+            params.layer.renderer = 'canvas';
+        }
+        /* We want the actions to trigger on the overview, but affect the main
+         * image, so we have to rerig all of the actions */
+        params.map.interactor = geo.mapInteractor({
+            actions: [{
+                action: 'overview_pan',
+                input: 'left',
+                modifiers: {shift: false, ctrl: false},
+                owner: 'histomicsui.overview',
+                name: 'button pan'
+            }, {
+                action: 'overview_zoomselect',
+                input: 'left',
+                modifiers: {shift: true, ctrl: false},
+                selectionRectangle: geo.event.zoomselect,
+                owner: 'histomicsui.overview',
+                name: 'drag zoom'
+            }],
+            keyboard: {
+                actions: {}
+            }
+        });
+        this.viewer = geo.map(params.map);
+
+        params.layer.autoshareRenderer = false;
+        this._tileLayer = this.viewer.createLayer('osm', params.layer);
+        this._featureLayer = this.viewer.createLayer('feature', {features: ['polygon']});
+        this._outlineFeature = this._featureLayer.createFeature('polygon', {style: {
+            stroke: true,
+            strokeColor: 'black',
+            strokeWidth: 2,
+            fill: false
+        }});
+        /* Clicking in the overview recenters to that spot */
+        this._featureLayer.geoOn(geo.event.mouseclick, (evt) => {
+            this.parentViewer.viewer.center(evt.geo);
+        });
+        this._featureLayer.geoOn(geo.event.actiondown, (evt) => {
+            this._downState = {
+                state: evt.state,
+                mouse: evt.mouse,
+                center: this.parentViewer.viewer.center(),
+                zoom: this.parentViewer.viewer.zoom(),
+                rotate: this.parentViewer.viewer.rotation()
+            };
+        });
+        this._featureLayer.geoOn(geo.event.actionmove, (evt) => {
+            switch (evt.state.action) {
+                case 'overview_pan':
+                    let delta = {
+                        x: evt.mouse.geo.x - this._downState.mouse.geo.x,
+                        y: evt.mouse.geo.y - this._downState.mouse.geo.y
+                    };
+                    let center = this.parentViewer.viewer.center();
+                    delta.x -= center.x - this._downState.center.x;
+                    delta.y -= center.y - this._downState.center.y;
+                    if (delta.x || delta.y) {
+                        this.parentViewer.viewer.center({
+                            x: center.x + delta.x,
+                            y: center.y + delta.y
+                        });
+                    }
+                    break;
+            }
+        });
+        this._featureLayer.geoOn(geo.event.actionselection, (evt) => {
+            if (evt.lowerLeft.x === evt.upperRight.x || evt.lowerLeft.y === evt.upperRight.y) {
+                return;
+            }
+            this.parentViewer.viewer.rotation(0);
+            let ll = this.viewer.displayToGcs(evt.lowerLeft);
+            let ur = this.viewer.displayToGcs(evt.upperRight);
+            this.parentViewer.viewer.bounds({
+                left: ll.x,
+                top: ur.y,
+                right: ur.x,
+                bottom: ll.y
+            });
+        });
+        this.viewer.draw();
+        this._boundOnParentPan = _.bind(this._onParentPan, this);
+        this.parentViewer.viewer.geoOn(geo.event.pan, this._boundOnParentPan);
+        this._onParentPan();
+    },
+
+    _onParentPan() {
+        let parent = this.parentViewer.viewer;
+        let size = parent.size();
+        this._outlineFeature.data([[
+            parent.displayToGcs({x: 0, y: 0}),
+            parent.displayToGcs({x: size.width, y: 0}),
+            parent.displayToGcs({x: size.width, y: size.height}),
+            parent.displayToGcs({x: 0, y: size.height})
+        ]]).draw();
+    }
+});
+
+export default OverviewWidget;

--- a/histomicsui/web_client/stylesheets/panels/overviewWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/overviewWidget.styl
@@ -1,0 +1,4 @@
+.h-overview-image
+  height 250px
+.h-overview-widget .s-panel-content
+  margin 0

--- a/histomicsui/web_client/templates/body/image.pug
+++ b/histomicsui/web_client/templates/body/image.pug
@@ -7,6 +7,7 @@
   .h-control-panel-container.s-panel-group.h-panel-group-left
     #h-analysis-panel
   #h-annotation-selector-container.s-panel-group.h-panel-group-right
+    #h-overview-panel.h-overview-widget.s-panel
     #h-zoom-panel.h-zoom-widget.s-panel
     #h-metadata-panel.h-metadata-widget.s-panel
     #h-annotation-panel.h-annotation-selector.s-panel

--- a/histomicsui/web_client/templates/panels/overviewWidget.pug
+++ b/histomicsui/web_client/templates/panels/overviewWidget.pug
@@ -1,0 +1,7 @@
+extends ./panel.pug
+
+block title
+  | #[span.icon-picture] Overview
+
+block content
+  .h-overview-image

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -17,6 +17,7 @@ import AnnotationCollection from '@girder/large_image_annotation/collections/Ann
 import AnnotationContextMenu from '../popover/AnnotationContextMenu';
 import AnnotationPopover from '../popover/AnnotationPopover';
 import AnnotationSelector from '../../panels/AnnotationSelector';
+import OverviewWidget from '../../panels/OverviewWidget';
 import ZoomWidget from '../../panels/ZoomWidget';
 import MetadataWidget from '../../panels/MetadataWidget';
 import DrawWidget from '../../panels/DrawWidget';
@@ -66,6 +67,9 @@ var ImageView = View.extend({
         this.controlPanel = new SlicerPanelGroup({
             parentView: this,
             closeButton: true
+        });
+        this.overviewWidget = new OverviewWidget({
+            parentView: this
         });
         this.zoomWidget = new ZoomWidget({
             parentView: this
@@ -217,6 +221,10 @@ var ImageView = View.extend({
                 // show the right side control container
                 this.$('#h-annotation-selector-container').removeClass('hidden');
 
+                this.overviewWidget
+                    .setViewer(this.viewerWidget)
+                    .setElement('.h-overview-widget').render();
+
                 this.zoomWidget
                     .setViewer(this.viewerWidget)
                     .setElement('.h-zoom-widget').render();
@@ -323,6 +331,7 @@ var ImageView = View.extend({
             }).then((tiles) => {
                 this.zoomWidget.setMaxMagnification(tiles.magnification || 20, this._increaseZoom2x, this._increaseZoom2xRange);
                 this.zoomWidget.render();
+                this.overviewWidget.setImage(tiles);
                 return null;
             });
         };

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -149,6 +149,7 @@ def testWebClientWithWorker(boundServer, fsAssetstore, db, admin, user, spec, gi
     'girderUISpec.js',
     'itemSpec.js',
     'panelLayoutSpec.js',
+    'overviewPanelSpec.js',
 ))
 def testWebClient(boundServer, fsAssetstore, db, admin, user, spec):
     copyHUITest()

--- a/tests/web_client_specs/overviewPanelSpec.js
+++ b/tests/web_client_specs/overviewPanelSpec.js
@@ -1,0 +1,111 @@
+/* global huiTest */
+
+girderTest.importPlugin('jobs', 'worker', 'large_image', 'large_image_annotation', 'slicer_cli_web', 'histomicsui');
+girderTest.addScript('/static/built/plugins/histomicsui/huiTest.js');
+
+girderTest.promise.done(function () {
+    huiTest.startApp();
+
+    describe('Overview panel tests', function () {
+        describe('setup', function () {
+            it('login', function () {
+                huiTest.login();
+            });
+
+            it('open image', function () {
+                huiTest.openImage('copy');
+            });
+            it('open a different image', function () {
+                huiTest.openImage('image');
+            });
+        });
+
+        describe('Check overview actions', function () {
+            var main, simulateEvent, overview, frameFeature;
+
+            function simulateAndWait(event, options, wait) {
+                wait = wait || 3;
+                var count = 0, waitFunc;
+                waitFunc = function () {
+                    count += 1;
+                    if (count < wait) {
+                        requestAnimationFrame(waitFunc);
+                    }
+                };
+                runs(function () {
+                    simulateEvent(event, options);
+                    window.requestAnimationFrame(waitFunc);
+                });
+                waitsFor(function () {
+                    return count >= wait;
+                });
+            }
+
+            it('overview updates on main image change', function () {
+                runs(function () {
+                    main = window.geo.jQuery('.geojs-map').data('data-geojs-map');
+                    overview = window.geo.jQuery('.geojs-map').eq(1).data('data-geojs-map');
+                    simulateEvent = overview.interactor().simulateEvent;
+                    frameFeature = overview.layers()[1].features()[0];
+                    var frame = frameFeature.data();
+                    main.zoom(main.zoom() + 2);
+                    expect(frameFeature.data()).not.toEqual(frame);
+                });
+            });
+            it('click pan', function () {
+                var center = main.center();
+                simulateAndWait('mousedown', { map: { x: 100, y: 100 }, button: 'left' });
+                simulateAndWait('mouseup', { map: { x: 100, y: 100 }, button: 'left' });
+                runs(function () {
+                    expect(main.center()).not.toEqual(center);
+                });
+            });
+            it('click drag back to start', function () {
+                var center = main.center();
+                simulateAndWait('mousedown', { map: { x: 40, y: 20 }, button: 'left' });
+                simulateAndWait('mousemove', { map: { x: 40, y: 40 }, button: 'left' });
+                simulateAndWait('mousemove', { map: { x: 40, y: 20 }, button: 'left' });
+                simulateAndWait('mouseup', { map: { x: 40, y: 20 }, button: 'left' });
+                runs(function () {
+                    expect(main.center().x).toBeCloseTo(center.x);
+                    expect(main.center().y).toBeCloseTo(center.y);
+                });
+            });
+            it('click drag', function () {
+                var center = main.center();
+                simulateAndWait('mousedown', { map: { x: 40, y: 20 }, button: 'left' });
+                simulateAndWait('mousemove', { map: { x: 40, y: 40 }, button: 'left' });
+                simulateAndWait('mousemove', { map: { x: 40, y: 50 }, button: 'left' });
+                simulateAndWait('mouseup', { map: { x: 40, y: 50 }, button: 'left' });
+                runs(function () {
+                    expect(main.center().x).toBeCloseTo(center.x);
+                    expect(main.center().y).not.toBeCloseTo(center.y);
+                });
+            });
+            it('left-click drag zero area', function () {
+                var center = main.center();
+                var zoom = main.zoom();
+                simulateAndWait('mousedown', { map: { x: 40, y: 20 }, button: 'left', modifiers: 'shift' });
+                simulateAndWait('mousemove', { map: { x: 40, y: 20 }, button: 'left', modifiers: 'shift' });
+                simulateAndWait('mousemove', { map: { x: 40, y: 40 }, button: 'left', modifiers: 'shift' });
+                simulateAndWait('mouseup', { map: { x: 40, y: 40 }, button: 'left', modifiers: 'shift' });
+                runs(function () {
+                    expect(main.center()).toEqual(center);
+                    expect(main.zoom()).toEqual(zoom);
+                });
+            });
+            it('left-click drag', function () {
+                var center = main.center();
+                var zoom = main.zoom();
+                simulateAndWait('mousedown', { map: { x: 40, y: 20 }, button: 'left', modifiers: 'shift' });
+                simulateAndWait('mousemove', { map: { x: 40, y: 40 }, button: 'left', modifiers: 'shift' });
+                simulateAndWait('mousemove', { map: { x: 60, y: 40 }, button: 'left', modifiers: 'shift' });
+                simulateAndWait('mouseup', { map: { x: 60, y: 40 }, button: 'left', modifiers: 'shift' });
+                runs(function () {
+                    expect(main.center()).not.toEqual(center);
+                    expect(main.zoom()).not.toEqual(zoom);
+                });
+            });
+        });
+    });
+});

--- a/tests/web_client_specs/panelLayoutSpec.js
+++ b/tests/web_client_specs/panelLayoutSpec.js
@@ -55,7 +55,7 @@ girderTest.promise.done(function () {
                     var rightIds = right.map(function (idx, panel) {
                         return $(panel).attr('id');
                     });
-                    expect(rightIds.toArray()).toEqual(['h-annotation-panel', 'h-metadata-panel', 'h-draw-panel']);
+                    expect(rightIds.toArray()).toEqual(['h-annotation-panel', 'h-metadata-panel', 'h-overview-panel', 'h-draw-panel']);
                 });
                 waitsFor(function () {
                     return !$('#h-annotation-panel .s-panel-content').hasClass('in');


### PR DESCRIPTION
Add controls to the overview.  Clicking recenters to that point.  Shift-left drag zooms to the selected rectangle (and unrotates).  Left drag pans.

There may be better controls.  Perhaps the left drag control shouldn't operate unless started in the view rectangle.  The view rectangle could have annotation-like handles.  The mouse wheel and pinch gestures could do zoom and rotate (and, if so, should zoom be animated)?

Closes #15.