### PR TITLE
Prevent invalid overview resizing.

### DIFF
--- a/histomicsui/web_client/panels/OverviewWidget.js
+++ b/histomicsui/web_client/panels/OverviewWidget.js
@@ -35,8 +35,10 @@ var OverviewWidget = Panel.extend({
     },
 
     setImage(tiles) {
-        this._tiles = tiles;
-        this._createOverview();
+        if (!_.isEqual(tiles, this._tiles)) {
+            this._tiles = tiles;
+            this._createOverview();
+        }
         return this;
     },
 
@@ -79,6 +81,15 @@ var OverviewWidget = Panel.extend({
             }
         });
         this.viewer = geo.map(params.map);
+
+        if (window.ResizeObserver) {
+            this._observer = new window.ResizeObserver(() => {
+                if (this.viewer.node().width()) {
+                    this.viewer.size({width: this.viewer.node().width(), height: this.viewer.node().height()});
+                }
+            });
+            this._observer.observe(this.viewer.node()[0]);
+        }
 
         params.layer.autoshareRenderer = false;
         this._tileLayer = this.viewer.createLayer('osm', params.layer);


### PR DESCRIPTION
If the overview panel is collapsed and is asked to rerender, the map ended up being 512 pixels wide.  There were two separate effects that could result in this behavior.  When a new analysis task is loaded, the overview panel has the tile source updated, even though it didn't change.  Any such update resulted in recreating the map unnecessarily.

When the map was created, if the div for the map was not visible due to being collapsed, it has a zero width.  geojs defaults to 512 pixels wide in this case.  Further, if the div changed size without the window changing size, that map was not updated appropriately (for instance, when the scroll bar appears or disappears).  Use a ResizeObserver, if available, to adjust the map when either condition occurs.