### PR TITLE
Drop support for Python 2.7 and 3.5.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,20 +34,6 @@ commands:
           command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; codecov --required --disable search pycov gcov --root project --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
 
 jobs:
-  py27:
-    executor: toxandnode
-    steps:
-      - checkout
-      - tox:
-          env: py27
-      - coverage
-  py35:
-    executor: toxandnode
-    steps:
-      - checkout
-      - tox:
-          env: py35
-      - coverage
   py36:
     executor: toxandnode
     steps:
@@ -97,20 +83,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - py27:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore:
-                - gh-pages
-      - py35:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore:
-                - gh-pages
       - py36:
           filters:
             tags:
@@ -148,8 +120,6 @@ workflows:
                 - gh-pages
       - release:
           requires:
-            - py27
-            - py35
             - py36
             - py37
             - py38

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 dist: xenial
 language: python
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Installation
 Linux
 =====
 
-In linux with Python 2.7, Python 3.5, 3.6, or 3.7:
+In linux with Python 3.6 or newer:
 
 Prerequisites:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 # Top level dependencies
 girder>=3.0.4 ; python_version < '3.8'
 girder>=3.0.13.dev6 ; python_version >= '3.8'
-girder-jobs>=3.0.3,<3.1 ; python_version < '3.6'
-girder-jobs>=3.0.3 ; python_version >= '3.6'
+girder-jobs>=3.0.3
 # We install only the tile sources we need for testing; using [all] is probably
 # better for development.
 large-image[openslide,pil]>=1.0.2.dev2

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -46,10 +43,7 @@ setup(
         'girder-large-image-annotation>=1.0.2.dev2',
         'girder-slicer-cli-web[girder]>=1.0.1.dev3',
         'girder-worker[girder]>=0.6.0',
-        'girder-client<3.1;python_version<"3.6"',
         'celery>=4.4.0rc5',
-        # Needed for Python 2.7 and Girder worker
-        'diskcache<5;python_version<"3"',
     ],
     license='Apache Software License 2.0',
     long_description=readme,
@@ -59,7 +53,7 @@ setup(
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/DigitalSlideArchive/histomicsui',
     zip_safe=False,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.6',
     entry_points={
         'girder.plugin': [
             'histomicsui = histomicsui:GirderPlugin'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{27,35,36,37,38}
+  py{36,37,38,39}
   flake8
   lintclient
 
@@ -10,8 +10,7 @@ deps =
   mock
   pytest
   pytest-cov
-  pytest-girder>=3.0.5; python_version >= '3.6'
-  pytest-girder>=3.0.5,<3.1; python_version < '3.6'
+  pytest-girder>=3.0.5
   pytest-xdist
   celery!=4.4.4,<5
   urllib3<1.26
@@ -31,7 +30,7 @@ skipsdist = true
 skip_install = true
 deps =
   flake8
-  flake8-blind-except; python_version >= '3.5'
+  flake8-blind-except
   flake8-bugbear
   flake8-docstrings
   flake8-quotes
@@ -99,7 +98,7 @@ ignore =
   W504
 
 [pytest]
-addopts = --verbose --strict --showlocals --cov-report="term" --cov-report="xml" --cov
+addopts = --verbose --strict-markers --showlocals --cov-report="term" --cov-report="xml" --cov
 testpaths = tests
 
 [coverage:paths]


### PR DESCRIPTION
They are both end-of-life.

Closes #89.