### PR TITLE
Add a metadata plot panel.

### DIFF
--- a/histomicsui/web_client/dialogs/index.js
+++ b/histomicsui/web_client/dialogs/index.js
@@ -4,6 +4,7 @@ import openImage from './openImage';
 import editElement from './editElement';
 import saveAnnotation from './saveAnnotation';
 import editRegionOfInterest from './editRegionOfInterest';
+import metadataPlot from './metadataPlot';
 
 export {
     confirmDialog,
@@ -11,5 +12,6 @@ export {
     openImage,
     editElement,
     saveAnnotation,
-    editRegionOfInterest
+    editRegionOfInterest,
+    metadataPlot
 };

--- a/histomicsui/web_client/dialogs/metadataPlot.js
+++ b/histomicsui/web_client/dialogs/metadataPlot.js
@@ -1,0 +1,42 @@
+import View from '@girder/core/views/View';
+
+import metadataPlotDialog from '../templates/dialogs/metadataPlot.pug';
+import '@girder/core/utilities/jquery/girderModal';
+
+const MetadataPlotDialog = View.extend({
+    events: {
+        'click .h-submit': '_submit'
+    },
+
+    initialize(settings) {
+        this.plotConfig = settings.plotConfig;
+        this.plotOptions = settings.plotOptions;
+    },
+
+    render() {
+        this.$el.html(
+            metadataPlotDialog({
+                plotConfig: this.plotConfig,
+                plotOptions: this.plotOptions
+            })
+        ).girderModal(this);
+        return this;
+    },
+
+    _submit(evt) {
+        evt.preventDefault();
+        const configOptions = {
+            folder: this.$('#h-plot-folder').is(':checked')
+        };
+        ['x', 'y', 'r', 'c', 's'].forEach((series) => {
+            let val = this.$('#h-plot-series-' + series).val();
+            if (val !== '_none_' && val !== undefined) {
+                configOptions[series] = val;
+            }
+        });
+        this.result = configOptions;
+        this.$el.modal('hide');
+    }
+});
+
+export default MetadataPlotDialog;

--- a/histomicsui/web_client/panels/MetadataPlot.js
+++ b/histomicsui/web_client/panels/MetadataPlot.js
@@ -1,0 +1,290 @@
+import $ from 'jquery';
+import _ from 'underscore';
+
+import { restRequest } from '@girder/core/rest';
+
+import Panel from '@girder/slicer_cli_web/views/Panel';
+// import events from '@girder/core/events';
+
+import MetadataPlotDialog from '../dialogs/metadataPlot';
+import metadataPlotTemplate from '../templates/panels/metadataPlot.pug';
+import '../stylesheets/panels/metadataPlot.styl';
+
+var MetadataPlot = Panel.extend({
+    events: _.extend(Panel.prototype.events, {
+        'click .g-widget-metadata-plot-settings': function (event) {
+            const dlg = new MetadataPlotDialog({
+                plotOptions: this.getPlotOptions(),
+                plotConfig: this.plotConfig,
+                plotPanel: this,
+                el: $('#g-dialog-container'),
+                parentView: this
+            }).render();
+            dlg.$el.on('hidden.bs.modal', () => {
+                if (dlg.result !== undefined) {
+                    this.plotConfig = dlg.result;
+                    this.render();
+                }
+            });
+        },
+        'click .h-panel-maximize': function (event) {
+            this.$el.html('');
+            this.expand();
+            this.$('.s-panel-content').addClass('in');
+            let panelElem = this.$el.closest('.s-panel');
+            let maximize = !panelElem.hasClass('h-panel-maximized');
+            panelElem.toggleClass('h-panel-maximized', maximize);
+            panelElem.toggleClass('s-no-panel-toggle', maximize);
+            this.render();
+        }
+    }),
+
+    /**
+     * Creates a widget to display a plot of certain metadata, possibly
+     * including data from items in the same parent folder.
+     */
+    initialize: function (settings) {
+        this.settings = settings;
+        this.plotConfig = {
+            folder: true
+        };
+    },
+
+    getSiblingItems(folderId) {
+        var chunk = 100;
+        if (folderId !== this.parentFolderId) {
+            return null;
+        }
+        return restRequest({url: 'item', data: {folderId: folderId, offset: this.siblingItems.length, limit: chunk + 1}}).done((result) => {
+            if (folderId !== this.parentFolderId) {
+                return null;
+            }
+            this.siblingItems = this.siblingItems.concat(result.slice(0, chunk));
+            if (result.length > chunk) {
+                return this.getSiblingItems(folderId);
+            }
+            this.siblingItemsPromise.resolve(this.siblingItems);
+            return null;
+        });
+    },
+
+    setItem: function (item) {
+        this.item = item;
+        this.item.on('g:changed', function () {
+            this.render();
+        }, this);
+        if (this.parentFolderId !== item.get('folderId')) {
+            this.parentFolderId = null;
+            if (this.siblingItemPromise) {
+                this.siblingItemPromise.abort();
+            }
+            const plotOptions = this.getPlotOptions();
+            this.siblingItems = [];
+            this.collectedPlotData = null;
+            if (plotOptions.filter((v) => v.type === 'number').length >= 2) {
+                this.parentFolderId = item.get('folderId');
+                this.siblingItemsPromise = $.Deferred();
+                this.getSiblingItems(item.get('folderId'));
+            }
+        }
+        this.render();
+        return this;
+    },
+
+    /**
+     * Check if there is metadata that can be used for a plot.  Metadata is
+     * structured as a dictionary.  If a top-level key contains an array
+     * whose first element is an object, then any key in that object is a
+     * possible value to plot.  These keys are categorized based on if their
+     * values are numbers or strings.
+     *
+     * @returns {object[]} An alphabetized list of available keys.  Each entry
+     *   is an object with 'root', 'key' and 'type'.
+     */
+    getPlotOptions: function () {
+        if (!this.item || !this.item.id || !this.item.get('meta')) {
+            return [];
+        }
+        var meta = this.item.get('meta');
+        var results = [{root: 'Item', key: 'name', type: 'string', sort: '_name'}];
+        for (const [root, entry] of Object.entries(meta)) {
+            if (_.isArray(entry) && entry.length >= 1 && _.isObject(entry[0])) {
+                for (const [key, value] of Object.entries(entry[0])) {
+                    let type;
+                    if (_.isFinite(value)) {
+                        type = 'number';
+                    } else if (_.isString(value)) {
+                        type = 'string';
+                    }
+                    if (type) {
+                        results.push({root: root, key: key, type: type, sort: `${root}.${key}`.toLowerCase()});
+                    }
+                }
+            }
+        }
+        return results.sort((a, b) => a.sort.localeCompare(b.sort));
+    },
+
+    /**
+     * Collect all plot data into a single array with the current item first.
+     * Create a summary of each data field.  For numeric values, this is the
+     * minimum and maximum.  For all fields, this is the number of distinct
+     * values.  This is done for the current item's data and for all items
+     * combined.
+     */
+    getPlotData: function (plotConfig) {
+        const plotOptions = this.getPlotOptions();
+        const optDict = {};
+        plotOptions.forEach((opt) => { optDict[opt.sort] = opt; });
+        let plotData = {data: [], fieldToPlot: {}, plotToOpt: {}, ranges: {}};
+        const usedFields = ['x', 'y', 'r', 'c', 's'].filter((series) => plotConfig[series] && optDict[plotConfig[series]]).map((series) => {
+            if (!plotData.fieldToPlot[plotConfig[series]]) {
+                plotData.fieldToPlot[plotConfig[series]] = [];
+            }
+            plotData.fieldToPlot[plotConfig[series]].push(series);
+            plotData.plotToOpt[series] = optDict[plotConfig[series]];
+            return plotConfig[series];
+        });
+        const usedOptions = plotOptions.filter((opt) => usedFields.includes(opt.sort));
+        if (!usedOptions.length) {
+            return plotData;
+        }
+        let items = [];
+        if (plotConfig.folder) {
+            items = this.siblingItems.filter((d) => d.largeImage && !d.largeImage.expected && d.meta && d._id !== this.item.id);
+        }
+        items.unshift(this.item.toJSON());
+        items.forEach((item, itemIdx) => {
+            let meta = item.meta;
+            let end = false;
+            for (let idx = 0; !end; idx += 1) {
+                let entry = {};
+                usedOptions.forEach((opt) => {
+                    plotData.fieldToPlot[opt.sort].forEach((key) => {
+                        let value;
+                        if (opt.sort === '_name') {
+                            value = item.name;
+                        } else if (meta[opt.root] && meta[opt.root][idx]) {
+                            value = meta[opt.root][idx][opt.key];
+                        }
+                        if (value === undefined || (opt.type === 'number' && !_.isFinite(value))) {
+                            end = true;
+                        }
+                        if (opt.type === 'string') {
+                            value = '' + value;
+                        }
+                        entry[key] = value;
+                    });
+                });
+                if (!end) {
+                    plotData.data.push(entry);
+                }
+            }
+        });
+        plotData.data.forEach((entry, idx) => {
+            Object.entries(entry).forEach(([key, value]) => {
+                if (!plotData.ranges[key]) {
+                    if (_.isFinite(value)) {
+                        plotData.ranges[key] = {min: value, max: value};
+                    } else {
+                        plotData.ranges[key] = {distinct: {}};
+                    }
+                }
+                if (_.isFinite(value)) {
+                    if (value < plotData.ranges[key].min) {
+                        plotData.ranges[key].min = value;
+                    }
+                    if (value > plotData.ranges[key].max) {
+                        plotData.ranges[key].max = value;
+                    }
+                } else {
+                    plotData.ranges[key].distinct[value] = true;
+                    plotData.ranges[key].list = Object.keys(plotData.ranges[key].distinct).sort();
+                    plotData.ranges[key].count = plotData.ranges[key].list.length;
+                }
+            });
+        });
+        return plotData;
+    },
+
+    plotDataToPlotly: function (plotData) {
+        let colorBrewerPaired12 = ['#a6cee3', '#1f78b4', '#b2df8a', '#33a02c', '#fb9a99', '#e31a1c', '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a', '#ffff99', '#b15928'];
+        let viridis = ['#440154', '#482172', '#423d84', '#38578c', '#2d6f8e', '#24858d', '#1e9a89', '#2ab07e', '#51c468', '#86d449', '#c2df22', '#fde724'];
+        let colorScale;
+        if (plotData.ranges.c && !plotData.ranges.c.count) {
+            colorScale = window.d3.scale.linear().domain(viridis.map((_, i) => i / (viridis.length - 1) * (plotData.ranges.c.max - plotData.ranges.c.min) + plotData.ranges.c.min)).range(viridis);
+        }
+        let plotlyData = {
+            x: plotData.data.map((d) => d.x),
+            y: plotData.data.map((d) => d.y),
+            hovertext: plotData.data.map((d) => {
+                let parts = [];
+                ['x', 'y', 'r', 'c', 's'].forEach((series) => {
+                    if (d[series] !== undefined) {
+                        parts.push(`${plotData.plotToOpt[series].root} - ${plotData.plotToOpt[series].key}: ${d[series]}`);
+                    }
+                });
+                return '<span style="font-size: 9px">' + parts.join('<br>') + '</span>';
+            }),
+            hoverinfo: 'text',
+            marker: {
+                symbol: plotData.ranges.s && plotData.ranges.s.count ? plotData.data.map((d) => plotData.ranges.s.list.indexOf(d.s)) : 0,
+                size: plotData.ranges.r ? (
+                    !plotData.ranges.r.count
+                        ? plotData.data.map((d) => (d.r - plotData.ranges.r.min) / (plotData.ranges.r.max - plotData.ranges.r.min) * 10 + 5)
+                        : plotData.data.map((d) => plotData.ranges.r.list.indexOf(d.r) / plotData.ranges.r.count * 10 + 5)
+                ) : 10,
+                color: plotData.ranges.c ? (
+                    !plotData.ranges.c.count
+                        ? plotData.data.map((d) => colorScale(d.c))
+                        : plotData.data.map((d) => colorBrewerPaired12[plotData.ranges.c.list.indexOf(d.c)] || '#000000')
+                ) : '#000000',
+                opacity: 0.5
+            },
+            type: plotData.data.length > 100 ? 'scattergl' : 'scatter',
+            mode: 'markers'
+        };
+        return [plotlyData];
+    },
+
+    render: function () {
+        if (this.item && this.item.id) {
+            const plotOptions = this.getPlotOptions();
+            if (plotOptions.filter((v) => v.type === 'number').length < 2) {
+                this.$el.html('');
+                return;
+            }
+            $.when(
+                this.siblingItemsPromise,
+                $.ajax({ // like $.getScript, but allow caching
+                    url: 'https://cdn.plot.ly/plotly-latest.min.js',
+                    dataType: 'script',
+                    cache: true
+                })
+            ).done(() => {
+                let plotData = this.getPlotData(this.plotConfig);
+                this.$el.html(metadataPlotTemplate({}));
+                const elem = this.$el.find('.h-metadata-plot-area');
+                if (!plotData.ranges.x || !plotData.ranges.y || plotData.data.length < 2) {
+                    elem.html('');
+                    return;
+                }
+                const maximized = this.$el.closest('.h-panel-maximized').length > 0;
+                let plotOptions = {
+                    margin: {t: 0, l: 40, r: 0, b: 20},
+                    hovermode: 'closest'
+                };
+                if (maximized) {
+                    plotOptions.margin.l += 20;
+                    plotOptions.margin.b += 40;
+                    plotOptions.xaxis = {title: {text: `${plotData.plotToOpt.x.root} - ${plotData.plotToOpt.x.key}`}};
+                    plotOptions.yaxis = {title: {text: `${plotData.plotToOpt.y.root} - ${plotData.plotToOpt.y.key}`}};
+                }
+                window.Plotly.newPlot(elem[0], this.plotDataToPlotly(plotData), plotOptions);
+            });
+        }
+        return this;
+    }
+});
+
+export default MetadataPlot;

--- a/histomicsui/web_client/panels/MetadataWidget.js
+++ b/histomicsui/web_client/panels/MetadataWidget.js
@@ -343,6 +343,15 @@ var MetadataWidget = Panel.extend({
         },
         'click .g-add-simple-metadata': function (event) {
             this.addMetadata(event, 'simple');
+        },
+        'click .h-panel-maximize': function (event) {
+            console.log(this);
+            this.expand();
+            this.$('.s-panel-content').addClass('in');
+            let panelElem = this.$el.closest('.s-panel');
+            let maximize = !panelElem.hasClass('h-panel-maximized');
+            panelElem.toggleClass('h-panel-maximized', maximize);
+            panelElem.toggleClass('s-no-panel-toggle', maximize);
         }
     }),
 

--- a/histomicsui/web_client/stylesheets/body/frontPage.styl
+++ b/histomicsui/web_client/stylesheets/body/frontPage.styl
@@ -44,3 +44,6 @@
 .hui-body .h-panel-title.s-panel-title
   white-space nowrap
   max-width 90%
+
+.s-panel-group .s-panel-title-container
+  line-height 1em

--- a/histomicsui/web_client/stylesheets/layout/layout.styl
+++ b/histomicsui/web_client/stylesheets/layout/layout.styl
@@ -61,3 +61,20 @@ body.hui-body
   min-height 0
   padding 0
   overflow hidden
+
+.h-panel-maximized
+  position fixed
+  top 50px
+  right 0
+  bottom 5px
+  left 5px
+  z-index 10000
+  display flex
+  flex-direction column
+  flex-wrap nowrap
+
+  .s-panel-content
+    overflow-y auto
+    flex-grow 1
+  i.icon-up-open
+    display none

--- a/histomicsui/web_client/stylesheets/panels/metadataPlot.styl
+++ b/histomicsui/web_client/stylesheets/panels/metadataPlot.styl
@@ -1,0 +1,23 @@
+.h-metadata-plot
+  margin 0
+
+  button.g-widget-metadata-plot-settings
+    float none
+    margin -2px 5px -2px 0
+    font-size 13px
+    padding 0 1px
+    height 21px
+    width 22px
+
+  .js-plotly-plot .plotly .modebar-btn
+    font-size 13px
+    padding 1px 2px
+
+  .h-metadata-plot-area.js-plotly-plot
+    min-height 266px
+    min-width 266px
+
+.h-panel-maximized
+  .h-metadata-plot-area.js-plotly-plot
+    height 100%
+    width 100%

--- a/histomicsui/web_client/stylesheets/panels/metadataWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/metadataWidget.styl
@@ -11,7 +11,7 @@
     max-width 100px
     display inline-block
     white-space nowrap
-    margin-bottom 2px
+    vertical-align middle
 
   .g-widget-metadata-row
     min-height 30px
@@ -37,7 +37,8 @@
 
   button.g-widget-metadata-add-button
     float none
-    margin 0 5px 0 0
+    margin -2px 5px -2px 0
+    font-size 10px
 
   .g-widget-metadata-container .g-widget-metadata-edit-button
     margin 2px 0 0

--- a/histomicsui/web_client/templates/body/image.pug
+++ b/histomicsui/web_client/templates/body/image.pug
@@ -10,6 +10,7 @@
     #h-overview-panel.h-overview-widget.s-panel
     #h-zoom-panel.h-zoom-widget.s-panel
     #h-metadata-panel.h-metadata-widget.s-panel
+    #h-metadataplot-panel.h-metadata-plot.s-panel
     #h-annotation-panel.h-annotation-selector.s-panel
     #h-draw-panel.h-draw-widget.s-panel.hidden
   #h-annotation-popover-container

--- a/histomicsui/web_client/templates/dialogs/metadataPlot.pug
+++ b/histomicsui/web_client/templates/dialogs/metadataPlot.pug
@@ -1,0 +1,32 @@
+.modal-dialog(role='document')
+  .modal-content
+    form.modal-form(role='form')
+      .modal-header
+        button.close(type='button', data-dismiss='modal', aria-label='Close')
+          span(aria-hidden='true') &times;
+        h4.modal-title Metadata Plot
+      .modal-body
+        -
+          var seriesList = [
+            {key: 'x', label: 'x-axis', number: true},
+            {key: 'y', label: 'y-axis', number: true},
+            {key: 'r', label: 'Radius'},
+            {key: 'c', label: 'Color'},
+            {key: 's', label: 'Symbol', string: true}]
+        for series in seriesList
+          .form-group
+            label(for='h-plot-series-' + series.key) #{series.label}
+            select.form-control(id='h-plot-series-' + series.key)
+              if !series.number
+                option(value='_none_', selected=plotConfig[series.key] === undefined) None
+              each opt in plotOptions
+                if (!series.number || opt.type === 'number') && (!series.string || opt.type === 'string')
+                  - var selected = plotConfig[series.key] === opt.sort
+                  option(value=opt.sort, selected=selected) #{opt.root + ' - ' + opt.key}
+        .form-group
+          label(for='h-plot-folder')
+            input#h-plot-folder(type='checkbox', checked=plotConfig.folder)
+            |  Include data from other items in the same folder
+      .modal-footer
+        button.btn.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel
+        button.btn.btn-primary.h-submit(type='submit') Save

--- a/histomicsui/web_client/templates/panels/metadataPlot.pug
+++ b/histomicsui/web_client/templates/panels/metadataPlot.pug
@@ -1,0 +1,13 @@
+extends ./panel.pug
+
+block title
+  | #[span.icon-chart-line] Metadata Plot
+block controls
+  span.s-no-panel-toggle
+    button.g-widget-metadata-plot-settings.btn.btn-sm.btn-default(title="Plot Settings")
+      i.icon-cog
+    span.s-no-panel-toggle.h-panel-maximize
+      i.icon-resize-full(title="Maximize")
+
+block content
+  .h-metadata-plot-area

--- a/histomicsui/web_client/templates/panels/metadataWidget.pug
+++ b/histomicsui/web_client/templates/panels/metadataWidget.pug
@@ -1,28 +1,23 @@
-.s-panel-title-container
-  span.s-panel-title.h-panel-title
-    i.icon-tags
-    |  #{title}
+extends ./panel.pug
+
+block title
+  | #[span.icon-tags] #{title}
   if(firstKey && firstValue)
     span.g-widget-metadata-header-key-value #{firstKey+' '+firstValue+'  '}
-  span.s-panel-controls
-    if (accessLevel >= AccessType.WRITE)
-      // new class introduced in the mentioned PR
-      span.s-no-panel-toggle
-        button.g-widget-metadata-add-button.btn.btn-sm.btn-primary.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata")
-          i.icon-plus
-        ul.dropdown-menu.pull-right(role="menu")
-          li(role="presentation")
-            a.g-add-simple-metadata(role="menuitem")
-              | Simple
-          li(role="presentation")
-            a.g-add-json-metadata
-              | JSON
-    if collapsed
-      i.icon-down-open
-    else
-      i.icon-up-open
-- var attrs = {}
-if !collapsed
-  - attrs.class = 'in'
-.s-panel-content.collapse&attributes(attrs)
+block controls
+  if (accessLevel >= AccessType.WRITE)
+    span.s-no-panel-toggle
+      button.g-widget-metadata-add-button.btn.btn-sm.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata")
+        i.icon-plus
+      ul.dropdown-menu.pull-right(role="menu")
+        li(role="presentation")
+          a.g-add-simple-metadata(role="menuitem")
+            | Simple
+        li(role="presentation")
+          a.g-add-json-metadata
+            | JSON
+    span.s-no-panel-toggle.h-panel-maximize
+      i.icon-resize-full(title="Maximize")
+
+block content
   .g-widget-metadata-container

--- a/histomicsui/web_client/templates/panels/panel.pug
+++ b/histomicsui/web_client/templates/panels/panel.pug
@@ -3,6 +3,7 @@
     block title
       | #{title}
   span.s-panel-controls
+    block controls
     if collapsed
       i.icon-down-open
     else

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -23,6 +23,7 @@ import AnnotationSelector from '../../panels/AnnotationSelector';
 import OverviewWidget from '../../panels/OverviewWidget';
 import ZoomWidget from '../../panels/ZoomWidget';
 import MetadataWidget from '../../panels/MetadataWidget';
+import MetadataPlot from '../../panels/MetadataPlot';
 import DrawWidget from '../../panels/DrawWidget';
 import editElement from '../../dialogs/editElement';
 import router from '../../router';
@@ -77,6 +78,9 @@ var ImageView = View.extend({
             parentView: this
         });
         this.metadataWidget = new MetadataWidget({
+            parentView: this
+        });
+        this.metadataPlot = new MetadataPlot({
             parentView: this
         });
         this.annotationSelector = new AnnotationSelector({
@@ -235,6 +239,10 @@ var ImageView = View.extend({
                 this.metadataWidget
                     .setItem(this.model)
                     .setElement('.h-metadata-widget').render();
+
+                this.metadataPlot
+                    .setItem(this.model)
+                    .setElement('.h-metadata-plot').render();
 
                 this.annotationSelector
                     .setViewer(this.viewerWidget)

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -135,6 +135,7 @@ class MockSlicerCLIWebResource(Resource):
     'huiSpec.js',
     'itemSpec.js',
     'metadataPanelSpec.js',
+    'metadataPlotSpec.js',
     'overviewPanelSpec.js',
     'panelLayoutSpec.js',
 ))

--- a/tests/web_client_specs/metadataPlotSpec.js
+++ b/tests/web_client_specs/metadataPlotSpec.js
@@ -1,0 +1,143 @@
+/* global huiTest */
+
+girderTest.importPlugin('jobs', 'worker', 'large_image', 'large_image_annotation', 'slicer_cli_web', 'histomicsui');
+girderTest.addScript('/static/built/plugins/histomicsui/huiTest.js');
+
+girderTest.promise.done(function () {
+    huiTest.startApp();
+
+    describe('Metadata plot tests', function () {
+        describe('setup', function () {
+            it('login', function () {
+                huiTest.login();
+            });
+            it('open image', function () {
+                huiTest.openImage('image');
+            });
+            it('no plot panel without metadata', function () {
+                runs(function () {
+                    expect($('#h-metadataplot-panel').length).toBe(1);
+                    expect($('#h-metadataplot-panel .s-panel-content').length).toBe(0);
+                });
+            });
+            it('add metadata to this and a second image', function () {
+                runs(function () {
+                    girder.rest.restRequest({
+                        url: 'item/' + huiTest.imageId() + '/metadata',
+                        contentType: 'application/json',
+                        processData: false,
+                        method: 'PUT',
+                        data: JSON.stringify({gloms: [{
+                            Label: 'Old',
+                            pas: 2680.166436339452,
+                            area: 783.110155889082,
+                            aspect: 2.9080459770114944,
+                            average: 164.37993900822062,
+                            std: 26.010079499756575
+                        }, {
+                            Label: 'Old',
+                            pas: 12980.996970666974,
+                            area: 1496.7676319940551,
+                            aspect: 1.9185185185185185,
+                            average: 155.27579392594646,
+                            std: 28.416844030625626
+                        }, {
+                            Label: 'Young',
+                            pas: 8402.006745559294,
+                            area: 1788.302533363278,
+                            aspect: 1.019704433497537,
+                            average: 159.67405227626796,
+                            std: 33.87920305083972
+                        }]}),
+                        async: false
+                    });
+                });
+                huiTest.openImage('copy');
+                runs(function () {
+                    girder.rest.restRequest({
+                        url: 'item/' + huiTest.imageId() + '/metadata',
+                        contentType: 'application/json',
+                        processData: false,
+                        method: 'PUT',
+                        data: JSON.stringify({gloms: [{
+                            Label: 'Young',
+                            pas: 11851.975039865125,
+                            area: 2360.3514018844844,
+                            aspect: 1.0686695278969958,
+                            average: 156.98394786336002,
+                            std: 31.21637278966411
+                        }, {
+                            Label: 'Old',
+                            pas: 14936.277054529173,
+                            area: 3136.911379889736,
+                            aspect: 1.0586080586080586,
+                            average: 156.36041872733267,
+                            std: 25.653667101657856
+                        }, {
+                            Label: 'Old',
+                            pas: 16794.292195370363,
+                            area: 3383.7387179248767,
+                            aspect: 1.08,
+                            average: 162.33947155279122,
+                            std: 29.727093069010945
+
+                        }]}),
+                        async: false
+                    });
+                });
+                huiTest.openImage('image');
+                waitsFor(function () {
+                    return $('#h-metadataplot-panel .s-panel-content').length;
+                }, 'panel to exist');
+            });
+            it('Show a plot', function () {
+                runs(function () {
+                    $('.g-widget-metadata-plot-settings').click();
+                });
+                girderTest.waitForDialog();
+                runs(function () {
+                    $('#h-plot-series-x').val('gloms.pas');
+                    $('#h-plot-series-y').val('gloms.area');
+                    $('#h-plot-series-r').val('gloms.aspect');
+                    $('#h-plot-series-c').val('gloms.label');
+                    $('#h-plot-series-s').val('_name');
+                    $('.h-submit').click();
+                });
+                girderTest.waitForLoad();
+                waitsFor(function () {
+                    return $('.plot-container.plotly').length;
+                }, 'plot to show up');
+                runs(function () {
+                    expect($('path[class=point]').length).toBe(6);
+                    expect($('path[class=point]').eq(0).css('fill')).toBe('#a6cee3');
+                    expect($('path[class=point]').eq(1).css('fill')).toBe('#a6cee3');
+                    expect($('path[class=point]').eq(2).css('fill')).toBe('#1f78b4');
+                });
+            });
+            it('Exclude neighboring data', function () {
+                runs(function () {
+                    $('.g-widget-metadata-plot-settings').click();
+                });
+                girderTest.waitForDialog();
+                runs(function () {
+                    // switch some other options, too.
+                    $('#h-plot-series-r').val('gloms.label');
+                    $('#h-plot-series-c').val('gloms.average');
+                    $('#h-plot-folder').prop('checked', false);
+                    $('.h-submit').click();
+                });
+                girderTest.waitForLoad();
+                waitsFor(function () {
+                    return $('path[class=point]').length !== 6 && $('.plot-container.plotly').length;
+                }, 'plot to show up');
+                runs(function () {
+                    expect($('path[class=point]').length).toBe(3);
+                    // check that the colors have changed
+                    expect($('path[class=point]').eq(0).css('fill')).toBe('#fde724');
+                    expect($('path[class=point]').eq(1).css('fill')).toBe('#440154');
+                    expect($('path[class=point]').eq(2).css('fill')).toBe('#228c8c');
+                });
+            });
+        });
+    });
+});

--- a/tests/web_client_specs/panelLayoutSpec.js
+++ b/tests/web_client_specs/panelLayoutSpec.js
@@ -55,7 +55,7 @@ girderTest.promise.done(function () {
                     var rightIds = right.map(function (idx, panel) {
                         return $(panel).attr('id');
                     });
-                    expect(rightIds.toArray()).toEqual(['h-annotation-panel', 'h-metadata-panel', 'h-overview-panel', 'h-draw-panel']);
+                    expect(rightIds.toArray()).toEqual(['h-annotation-panel', 'h-metadata-panel', 'h-overview-panel', 'h-metadataplot-panel', 'h-draw-panel']);
                 });
                 waitsFor(function () {
                     return !$('#h-annotation-panel .s-panel-content').hasClass('in');


### PR DESCRIPTION
If metadata exists in the form key: array of objects, and the first element of such an array has numerical values, then the option to plot the data, possibly with data from sibling items in the same folder is presented.  This pulls plotly from a CDN if needed.  If the current item's metadata doesn't allow for a plot, no extra http requests are made.

Use closest hovermode in plotly.  The default hovermode is unintuitive.  

Add axis titles when the graph is maximized.

Added a control for maximizing the plot size.