### PR TITLE
Adjust zoom control padding.

### DIFF
--- a/histomicsui/web_client/stylesheets/panels/zoomWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/zoomWidget.styl
@@ -7,6 +7,8 @@
     border 1px solid #ccc
     border-radius 2px
     min-width 4em
+    padding-left 0
+    padding-right 0
 
   .h-zoom-buttons
     margin-top 10px


### PR DESCRIPTION
This allows high zoom values to not enlarge the control before it is necessary.