### PR TITLE
Make analysis an extra_requires.

### DIFF
--- a/histomicsui/__init__.py
+++ b/histomicsui/__init__.py
@@ -19,7 +19,7 @@ import os
 import re
 
 from bson import json_util
-from girder import events, plugin
+from girder import events, logger, plugin
 from girder.api import access
 from girder.exceptions import ValidationException
 from girder.models.folder import Folder
@@ -195,9 +195,13 @@ class GirderPlugin(plugin.GirderPlugin):
     DISPLAY_NAME = 'HistomicsUI'
     CLIENT_SOURCE_PATH = 'web_client'
 
-    def load(self, info):
+    def load(self, info):  # noqa
         plugin.getPlugin('jobs').load(info)
-        plugin.getPlugin('slicer_cli_web').load(info)
+        try:
+            plugin.getPlugin('slicer_cli_web').load(info)
+        except Exception:
+            logger.info('slicer_cli_web plugin is unavailable.  Analysis '
+                        'tasks are therefore unavailable.')
         plugin.getPlugin('large_image_annotation').load(info)
 
         # Python's http cookie parser fails for all cookies when there are some

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,12 @@ setup(
     ],
     install_requires=[
         'girder-large-image-annotation>=1.4.2',
-        'girder-slicer-cli-web[girder]>=1.2.0',
-        'girder-worker[girder]>=0.6.0',
-        'celery>=4.4.0rc5',
     ],
+    extras_require={
+        'analysis': [
+            'girder-slicer-cli-web[girder]>=1.2.0',
+        ],
+    },
     license='Apache Software License 2.0',
     long_description=readme,
     long_description_content_type='text/x-rst',

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
   celery!=4.4.4,<5
   urllib3<1.26
   -rrequirements-dev.txt
+extras =
+  analysis
 whitelist_externals =
   rm
   npx


### PR DESCRIPTION
Projects that don't use slicer_cli_web jobs shouldn't be required to install all of the dependencies for it.