### PR TITLE
Clamp image viewer bounds, even with overlays

### DIFF
--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -177,6 +177,10 @@ var ImageView = View.extend({
                 highlightFeatureSizeLimit: 5000,
                 scale: { position: { bottom: 20, right: 10 } }
             });
+            // Don't unclamp bounds for the image even if image overlays are present.
+            if (this.viewerWidget.setUnclampBoundsForOverlay) {
+                this.viewerWidget.setUnclampBoundsForOverlay(false);
+            }
             this.trigger('h:viewerWidgetCreated', this.viewerWidget);
 
             // handle annotation mouse events


### PR DESCRIPTION
Recent [changes](https://github.com/girder/large_image/pull/750) to the `large_image` girder plugin allowed for image overlay annotations. With those changes, the default behavior for the underlying `geojs` map is to unclamp bounds while image overlays are drawn on the base image. This allows for panning to image overlays that are drawn off of the base image, but removes the ability to scroll out to center the base image.

For HistomicsUI, we will keep the `geojs` map bounds clamped to the base image. This preserves the usability gained from scroll out to center.