### PR TITLE
Add an endpoint to find a json config file.

### DIFF
--- a/histomicsui/handlers.py
+++ b/histomicsui/handlers.py
@@ -119,7 +119,7 @@ def process_annotations(event):
         logger.error('Could not load models from the database')
         return
     try:
-        data = json.loads(b''.join(File().download(file)()).decode('utf8'))
+        data = json.loads(b''.join(File().download(file)()).decode())
     except Exception:
         logger.error('Could not parse annotation file')
         raise
@@ -229,7 +229,7 @@ def process_metadata(event):
         logger.error('Could not load models from the database')
         return
     try:
-        data = json.loads(b''.join(File().download(file)()).decode('utf8'))
+        data = json.loads(b''.join(File().download(file)()).decode())
     except Exception:
         logger.error('Could not parse metadata file')
         raise

--- a/histomicsui/rest/system.py
+++ b/histomicsui/rest/system.py
@@ -1,4 +1,4 @@
-###############################################################################
+#############################################################################
 #  Copyright Kitware Inc.
 #
 #  Licensed under the Apache License, Version 2.0 ( the "License" );
@@ -12,13 +12,17 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-###############################################################################
+#############################################################################
 
+import json
+
+from girder import logger
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute, describeRoute
 from girder.api.rest import RestException, boundHandler, filtermodel
 from girder.api.v1.resource import Resource as ResourceResource
 from girder.constants import AccessType, TokenScope
+from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.utility.model_importer import ModelImporter
@@ -34,6 +38,7 @@ def addSystemEndpoints(apiRoot):
     apiRoot.item.route('GET', ('query',), getItemsByQuery)
     # Added to the folder route
     apiRoot.folder.route('GET', ('query',), getFoldersByQuery)
+    apiRoot.folder.route('GET', (':id', 'json_config', ':name'), getJSONConfigFile)
     # Added to the histomicui route
     HUIResourceResource(apiRoot)
 
@@ -165,6 +170,40 @@ def getItemsByQuery(self, query, limit, offset, sort):
 def getFoldersByQuery(self, query, limit, offset, sort):
     user = self.getCurrentUser()
     return Folder().findWithPermissions(query, offset=offset, limit=limit, sort=sort, user=user)
+
+
+@access.public(scope=TokenScope.DATA_READ)
+@autoDescribeRoute(
+    Description(
+        'Get a config file.  This walks up the chain of parent folders until '
+        'the file is found.  If not found, the .config folder in the parent '
+        'collection or user is checked.')
+    .modelParam('id', model=Folder, level=AccessType.READ)
+    .param('name', 'The name of the file.', paramType='path')
+    .errorResponse()
+)
+@boundHandler()
+def getJSONConfigFile(self, folder, name):
+    user = self.getCurrentUser()
+    while folder:
+        item = Item().findOne({'folderId': folder['_id'], 'name': name},
+                              user=user, level=AccessType.READ)
+        if item:
+            for file in Item().childFiles(item):
+                if file['size'] > 10 * 1024 ** 2:
+                    logger.info('Not loading %s -- too large' % file['name'])
+                    continue
+                with File().open(file) as fptr:
+                    return json.loads(fptr.read())
+        if folder['parentCollection'] != 'folder':
+            if folder['name'] == '.config':
+                break
+            folder = Folder().findOne({
+                'parentId': folder['parentId'],
+                'parentCollection': folder['parentCollection'],
+                'name': '.config'})
+        else:
+            folder = Folder().load(folder['parentId'], user=user, level=AccessType.READ)
 
 
 class HUIResourceResource(ResourceResource):

--- a/tests/girder_utilities.py
+++ b/tests/girder_utilities.py
@@ -1,3 +1,4 @@
+import io
 import os
 
 from girder.models.folder import Folder
@@ -39,6 +40,13 @@ def uploadTestFile(fileName, user, assetstore, folderName='Public', name=None, r
         name=None, reference=reference)
 
 
+def uploadText(text, user, assetstore, folder, name):
+    file = Upload().uploadFromFile(
+        io.BytesIO(text.encode()), len(text), name,
+        parentType='folder', parent=folder, user=user, assetstore=assetstore)
+    return file
+
+
 def respStatus(resp):
     return int(resp.output_status.split()[0])
 
@@ -55,9 +63,9 @@ def getBody(response, text=True):
 
     for chunk in response.body:
         if text and isinstance(chunk, bytes):
-            chunk = chunk.decode('utf8')
+            chunk = chunk.decode()
         elif not text and not isinstance(chunk, bytes):
-            chunk = chunk.encode('utf8')
+            chunk = chunk.encode()
         data += chunk
 
     return data

--- a/tests/test_hui_rest.py
+++ b/tests/test_hui_rest.py
@@ -218,6 +218,42 @@ class TestHUIResourceAndItem:
         assert meta['keyb']['keyc'] is None
         assert meta['keyb']['keyd'] == 'valued'
 
+    def testJSONConfigFile(self, server, admin, fsAssetstore):
+        self.makeResources(admin)
+        resp = server.request(
+            path='/folder/%s/json_config/sample.json' % str(self.colFolderC['_id']),
+            method='GET')
+        assert utilities.respStatus(resp) == 200
+        assert resp.json is None
+
+        self.colFolderConfig = Folder().createFolder(
+            self.collection, '.config', parentType='collection',
+            creator=admin)
+        utilities.uploadText(
+            json.dumps({'keyA': 'value1'}),
+            admin, fsAssetstore, self.colFolderConfig, 'sample.json')
+        resp = server.request(
+            path='/folder/%s/json_config/sample.json' % str(self.colFolderC['_id']))
+        assert utilities.respStatus(resp) == 200
+        assert resp.json['keyA'] == 'value1'
+
+        utilities.uploadText(
+            json.dumps({'keyA': 'value2'}),
+            admin, fsAssetstore, self.colFolderA, 'sample.json')
+        resp = server.request(
+            path='/folder/%s/json_config/sample.json' % str(self.colFolderC['_id']))
+        assert utilities.respStatus(resp) == 200
+        assert resp.json['keyA'] == 'value2'
+
+        utilities.uploadText(
+            json.dumps({'keyA': 'value3'}),
+            admin, fsAssetstore, self.colFolderC, 'sample.json')
+        resp = server.request(
+            path='/folder/%s/json_config/sample.json' % str(self.colFolderC['_id']))
+        assert utilities.respStatus(resp) == 200
+        assert resp.json['keyA'] == 'value3'
+        # ##DWM::
+
 
 @pytest.mark.plugin('histomicsui')
 class TestHUIEndpoints:


### PR DESCRIPTION
This starts at a given directory and walks up until it finds an appropriate file.  If it reaches the user or collection, it looks in a ".config" folder for such a file.  Specifically, it tries the first file in an item with the specified name.