### PR TITLE
Don't close dialog when dragging outside of it

### DIFF
--- a/histomicsui/web_client/dialogs/saveAnnotation.js
+++ b/histomicsui/web_client/dialogs/saveAnnotation.js
@@ -169,6 +169,31 @@ function show(annotation, options) {
     dialog.annotation = annotation;
     dialog.options = options;
     dialog.setElement('#g-dialog-container').render();
+
+    // Bootstrap 3's default behavior is to close the modal when a
+    // `click` event occurs outside of the modal. By using the `click`
+    // event, the following scenario could occur -
+    // The user clicks and holds down the mouse button when the cursor
+    // is inside the modal, but releases when the mouse cursor is
+    // outside the modal. The browser will recognize this as a `click`
+    // event and will close the modal.
+    //
+    // Instead, we want this behavior to happen on a `mousedown` event.
+    // So, below we disable the auto-closing behavior and attach our
+    // own event listener to do it:
+    const dialogContainer = $('#g-dialog-container');
+
+    // Disable the auto-closing of the modal on `click`
+    // (see https://getbootstrap.com/docs/3.4/javascript/#modals-options)
+    dialogContainer.modal({backdrop: 'static'});
+
+    // Attach our own event listener to handle auto-closing the modal
+    dialogContainer.on('mousedown', (evt) => {
+        if (!evt.target.closest('.modal-content')) {
+            dialogContainer.modal('hide');
+        }
+    });
+
     return dialog;
 }
 

--- a/histomicsui/web_client/dialogs/saveAnnotation.js
+++ b/histomicsui/web_client/dialogs/saveAnnotation.js
@@ -169,31 +169,6 @@ function show(annotation, options) {
     dialog.annotation = annotation;
     dialog.options = options;
     dialog.setElement('#g-dialog-container').render();
-
-    // Bootstrap 3's default behavior is to close the modal when a
-    // `click` event occurs outside of the modal. By using the `click`
-    // event, the following scenario could occur -
-    // The user clicks and holds down the mouse button when the cursor
-    // is inside the modal, but releases when the mouse cursor is
-    // outside the modal. The browser will recognize this as a `click`
-    // event and will close the modal.
-    //
-    // Instead, we want this behavior to happen on a `mousedown` event.
-    // So, below we disable the auto-closing behavior and attach our
-    // own event listener to do it:
-    const dialogContainer = $('#g-dialog-container');
-
-    // Disable the auto-closing of the modal on `click`
-    // (see https://getbootstrap.com/docs/3.4/javascript/#modals-options)
-    dialogContainer.modal({backdrop: 'static'});
-
-    // Attach our own event listener to handle auto-closing the modal
-    dialogContainer.on('mousedown', (evt) => {
-        if (!evt.target.closest('.modal-content')) {
-            dialogContainer.modal('hide');
-        }
-    });
-
     return dialog;
 }
 

--- a/histomicsui/web_client/views/View.js
+++ b/histomicsui/web_client/views/View.js
@@ -1,3 +1,29 @@
+import $ from 'jquery';
 import View from '@girder/core/views/View';
 
-export default View;
+export default View.extend({
+    initialize() {
+        // Bootstrap 3's default behavior is to close dialogs when a
+        // `click` event occurs outside of it. By using the `click`
+        // event, the following scenario could occur -
+        // The user clicks and holds down the mouse button when the cursor
+        // is inside the dialog, but releases when the mouse cursor is
+        // outside the dialog. The browser will recognize this as a `click`
+        // event and will close the dialog.
+        //
+        // Instead, we want this behavior to happen on a `mousedown` event
+        // for all dialogs when the HistomicsUI plugin is present.
+        // So, below we attach our own event listener that disables the
+        // auto-closing behavior on `click` and does it instead on `mousedown`:
+        $(document).on('mousedown', '#g-dialog-container', (evt) => {
+            const dialogContainer = $('#g-dialog-container');
+            // Disable the `click` event listener. This works because the
+            // `mousedown` event is always fired before `click`.
+            dialogContainer.off('click');
+            // Close the dialog if the `mousedown` event was outside of it.
+            if (!evt.target.closest('.modal-content')) {
+                dialogContainer.modal('hide');
+            }
+        });
+    }
+});


### PR DESCRIPTION
This PR changes the behavior of the Bootstrap `modal` component to automatically close on `mousedown` instead of on `click`.
The latter is the default behavior of Bootstrap, so I attached a new event listener to accomplish this - see code comments for details.

Fixes #140 