### PR TITLE
Revert "Generalize the `mousedown` behavior for all modals"

### DIFF
--- a/histomicsui/web_client/views/View.js
+++ b/histomicsui/web_client/views/View.js
@@ -1,29 +1,3 @@
-import $ from 'jquery';
 import View from '@girder/core/views/View';
 
-export default View.extend({
-    initialize() {
-        // Bootstrap 3's default behavior is to close dialogs when a
-        // `click` event occurs outside of it. By using the `click`
-        // event, the following scenario could occur -
-        // The user clicks and holds down the mouse button when the cursor
-        // is inside the dialog, but releases when the mouse cursor is
-        // outside the dialog. The browser will recognize this as a `click`
-        // event and will close the dialog.
-        //
-        // Instead, we want this behavior to happen on a `mousedown` event
-        // for all dialogs when the HistomicsUI plugin is present.
-        // So, below we attach our own event listener that disables the
-        // auto-closing behavior on `click` and does it instead on `mousedown`:
-        $(document).on('mousedown', '#g-dialog-container', (evt) => {
-            const dialogContainer = $('#g-dialog-container');
-            // Disable the `click` event listener. This works because the
-            // `mousedown` event is always fired before `click`.
-            dialogContainer.off('click');
-            // Close the dialog if the `mousedown` event was outside of it.
-            if (!evt.target.closest('.modal-content')) {
-                dialogContainer.modal('hide');
-            }
-        });
-    }
-});
+export default View;


### PR DESCRIPTION
This reverts commit 4e591ebec3a2971b6e2333fe22836e4072a99031.

Revert "Use `mousedown` event instead of `click` for auto-closing modal"

This reverts commit 703e7338e9702bc379f9c6c767aa286ce50f1860.

This reopens #140 and closes #150.