### PR TITLE
Don't close dialog when dragging outside of it (take 2)

### DIFF
--- a/histomicsui/web_client/views/View.js
+++ b/histomicsui/web_client/views/View.js
@@ -1,3 +1,29 @@
+import $ from 'jquery';
 import View from '@girder/core/views/View';
 
-export default View;
+export default View.extend({
+    initialize() {
+        // Bootstrap 3's default behavior is to close dialogs when a
+        // `click` event occurs outside of it. By using the `click`
+        // event, the following scenario could occur -
+        // The user clicks and holds down the mouse button when the cursor
+        // is inside the dialog, but releases when the mouse cursor is
+        // outside the dialog. The browser will recognize this as a `click`
+        // event and will close the dialog.
+        //
+        // Instead, we want this behavior to happen on a `mousedown` event
+        // for all dialogs when the HistomicsUI plugin is present.
+        // So, below we attach our own event listener that disables the
+        // auto-closing behavior on `click` and does it instead on `mousedown`:
+        $(document).on('mousedown', '#g-dialog-container', (evt) => {
+            const dialogContainer = $('#g-dialog-container');
+            // Disable the `click` event listener. This works because the
+            // `mousedown` event is always fired before `click`.
+            dialogContainer.off('click', '#g-dialog-container');
+            // Close the dialog if the `mousedown` event was outside of it.
+            if (!evt.target.closest('.modal-content')) {
+                dialogContainer.modal('hide');
+            }
+        });
+    }
+});


### PR DESCRIPTION
@manthey this line was what broke some dialog boxes -
```javascript
dialogContainer.off('click');
```

When jQuery's `.off` method only receives one argument, it removes that event listener from the element it is called on and _also_ all of its children. So what was happening was that line was removing the `click` event listeners from the buttons within the dialogs too. `.off` takes a second argument that lets you specify a specific selector to remove the event listener from. I've done that here -
```javascript
dialogContainer.off('click', '#g-dialog-container');
```
So now it removes the `click` event listener from `#g-dialog-container` only, and not any of its children. I tested all of the dialogs I could find in the UI with this change, and it seems to work fine.

Fixes #140