### PR TITLE
Documentation improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,8 @@ Development
 
 The most convenient way to develop on HistomicsUI is to use the `devops scripts from the Digital Slide Archive <https://github.com/DigitalSlideArchive/digital_slide_archive/tree/master/devops>`_.
 
+If you are making changes to the HistomicsUI frontend, you can make Girder watch the source code and perform hot reloads on changes using the ``--watch-plugin`` argument to ``girder build``. See the `Girder docs <https://girder.readthedocs.io/en/stable/development.html#during-development>`_ for more information.
+
 Annotations and Metadata from Jobs
 ----------------------------------
 


### PR DESCRIPTION
Adds a note about enabling hot reloading for the web frontend.

@manthey this was the only slight pain point I ran into with spinning up the application locally. I didn't see this mentioned anywhere in the docs, but I was able to figure it out quickly by reading the girder 3 docs. Still, I think it is good to have a brief mention of it here.