### PR TITLE
Set `tabindex` of all dialog buttons

### DIFF
--- a/histomicsui/web_client/views/View.js
+++ b/histomicsui/web_client/views/View.js
@@ -25,5 +25,11 @@ export default View.extend({
                 dialogContainer.modal('hide');
             }
         });
+
+        // Whenever a new dialog is rendered in the DOM, set the tabindex
+        // of its buttons to 0 so they can be selected with the Tab key.
+        $(document).on('DOMNodeInserted', '#g-dialog-container', () => {
+            $('.btn').prop('tabindex', '0');
+        });
     }
 });

--- a/histomicsui/web_client/views/View.js
+++ b/histomicsui/web_client/views/View.js
@@ -29,7 +29,7 @@ export default View.extend({
         // Whenever a new dialog is rendered in the DOM, set the tabindex
         // of its buttons to 0 so they can be selected with the Tab key.
         $(document).on('DOMNodeInserted', '#g-dialog-container', () => {
-            $('.btn').prop('tabindex', '0');
+            $('.btn', '#g-dialog-container').prop('tabindex', '0');
         });
     }
 });


### PR DESCRIPTION
Adds an event listener that sets `tabindex=0` on all `.btn` elements whenever a new dialog is rendered.

Closes #145 