### PR TITLE
Fix create annotation keyboard shortcut bug

### DIFF
--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -1104,9 +1104,7 @@ var ImageView = View.extend({
                 this.annotationSelector.selectAnnotationByRegion();
                 break;
             case ' ': // pressing space bar creates a new annotation
-                if (!this.activeAnnotation) {
-                    this.annotationSelector.createAnnotation();
-                }
+                this.annotationSelector.createAnnotation();
                 break;
             case 'o':
                 if (this.activeAnnotation) {

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -1104,12 +1104,12 @@ var ImageView = View.extend({
                 this.annotationSelector.selectAnnotationByRegion();
                 break;
             case ' ': // pressing space bar creates a new annotation
-                if (!this.annotationSelector._activeAnnotation) {
+                if (!this.activeAnnotation) {
                     this.annotationSelector.createAnnotation();
                 }
                 break;
             case 'o':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     if (this.drawWidget._drawingType === 'point') {
                         this.drawWidget.cancelDrawMode();
                     } else {
@@ -1118,7 +1118,7 @@ var ImageView = View.extend({
                 }
                 break;
             case 'r':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     if (this.drawWidget._drawingType === 'rectangle') {
                         this.drawWidget.cancelDrawMode();
                     } else {
@@ -1127,7 +1127,7 @@ var ImageView = View.extend({
                 }
                 break;
             case 'i':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     if (this.drawWidget._drawingType === 'ellipse') {
                         this.drawWidget.cancelDrawMode();
                     } else {
@@ -1136,7 +1136,7 @@ var ImageView = View.extend({
                 }
                 break;
             case 'c':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     if (this.drawWidget._drawingType === 'circle') {
                         this.drawWidget.cancelDrawMode();
                     } else {
@@ -1145,7 +1145,7 @@ var ImageView = View.extend({
                 }
                 break;
             case 'p':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     if (this.drawWidget._drawingType === 'polygon') {
                         this.drawWidget.cancelDrawMode();
                     } else {
@@ -1154,7 +1154,7 @@ var ImageView = View.extend({
                 }
                 break;
             case 'l':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     if (this.drawWidget._drawingType === 'line') {
                         this.drawWidget.cancelDrawMode();
                     } else {
@@ -1163,18 +1163,18 @@ var ImageView = View.extend({
                 }
                 break;
             case 'q':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     this.drawWidget.setToPrevStyleGroup();
                 }
                 break;
             case 'w':
-                if (this.annotationSelector._activeAnnotation) {
+                if (this.activeAnnotation) {
                     this.drawWidget.setToNextStyleGroup();
                 }
                 break;
             case 'Enter':
                 const drawingType = this.drawWidget._drawingType;
-                if (this.annotationSelector._activeAnnotation && ['polygon', 'line'].includes(drawingType)) {
+                if (this.activeAnnotation && ['polygon', 'line'].includes(drawingType)) {
                     const annotation = this.viewerWidget.annotationLayer.annotations()[0];
 
                     // The current mouse position is included as the last vertex, so remove


### PR DESCRIPTION
The keyboard shortcut for creating a new annotation currently checks if `activeAnnotation` is truthy, and if so does nothing. I originally thought that `activeAnnotation` gets set to a falsey value when the annotation is deleted, but that isn't the case - it isn't changed at all, so it can't be relied upon to indicate whether or not an annotation is open. 

But, there's no need to even do that check, since there's no reason to prevent the user from creating a new annotation while they have another one open. So, I just removed it so the space bar will always work.

I also changed all uses of `this.annotationSelector._activeAnnotation` in the keyboard event handler to the more compact `this.activeAnnotation`. 

Closes #159 