### PR TITLE
Specify a background color for the brand in the title bar

### DIFF
--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -10,7 +10,7 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         span.icon-bar
         span.icon-bar
         span.icon-bar
-      a#h-navbar-brand.navbar-brand(style=`color: ${brandColor}`) #{brandName}
+      a#h-navbar-brand.navbar-brand(style=`color: ${brandColor}; background-color: ${bannerColor}`) #{brandName}
 
     #h-navbar-collapse.collapse.navbar-collapse
       ul.nav.navbar-nav.navbar-right


### PR DESCRIPTION
This prevents the filename from bleeding below it, which is hard to read.