### PR TITLE
Create links from hierarchy widget to images in Histomics UI

### DIFF
--- a/histomicsui/web_client/views/itemList.js
+++ b/histomicsui/web_client/views/itemList.js
@@ -60,11 +60,25 @@ wrap(ItemListWidget, 'render', function (render) {
         });
     }
 
-    if (this.accessLevel >= AccessType.WRITE) {
-        HuiSettings.getSettings().then((settings) => {
+    HuiSettings.getSettings().then((settings) => {
+        const brandName = (settings['histomicsui.brand_name'] || '');
+        const webrootPath = (settings['histomicsui.webroot_path'] || '');
+        for (let ix = 0; ix<this.collection.length; ix++) {
+            if (!this.$el.find('.g-item-list li:eq(' + ix + ') .g-hui-open-link').length && this.collection.models[ix].attributes.largeImage) {
+                this.$el.find('.g-item-list li:eq(' + ix + ')>.g-item-size').before(
+                    `<a class="g-hui-open-link" title="Open in ${brandName}" href="${webrootPath}#?image=${this.collection.models[ix].id}" target="_blank">
+                            <i class="icon-link-ext"></i>
+                    </a>`
+                );
+            }
+        }
+        if (this.accessLevel >= AccessType.WRITE) {
             adjustView(settings);
             return settings;
-        });
+        }
+    });
+
+    if (this.accessLevel >= AccessType.WRITE) {
         this.events['click .g-hui-quarantine'] = quarantine;
         this.delegateEvents();
     }

--- a/histomicsui/web_client/views/itemList.js
+++ b/histomicsui/web_client/views/itemList.js
@@ -63,7 +63,7 @@ wrap(ItemListWidget, 'render', function (render) {
     HuiSettings.getSettings().then((settings) => {
         const brandName = (settings['histomicsui.brand_name'] || '');
         const webrootPath = (settings['histomicsui.webroot_path'] || '');
-        for (let ix = 0; ix<this.collection.length; ix++) {
+        for (let ix = 0; ix < this.collection.length; ix++) {
             if (!this.$el.find('.g-item-list li:eq(' + ix + ') .g-hui-open-link').length && this.collection.models[ix].attributes.largeImage) {
                 this.$el.find('.g-item-list li:eq(' + ix + ')>.g-item-size').before(
                     `<a class="g-hui-open-link" title="Open in ${brandName}" href="${webrootPath}#?image=${this.collection.models[ix].id}" target="_blank">
@@ -74,8 +74,8 @@ wrap(ItemListWidget, 'render', function (render) {
         }
         if (this.accessLevel >= AccessType.WRITE) {
             adjustView(settings);
-            return settings;
         }
+        return settings;
     });
 
     if (this.accessLevel >= AccessType.WRITE) {


### PR DESCRIPTION
Makes it more convenient to view an image in the Histomics UI by creating a new option to open an image in the UI directly from the hierarchy widget (where items are listed).  The link is located directly to the right of the "View in browser" icon and is an open external link icon with an "Open in HistomicsUI" tooltip.

Closes #146 