### PR TITLE
Make long image annotation label titles wrap properly

### DIFF
--- a/histomicsui/web_client/stylesheets/popover/annotationPopover.styl
+++ b/histomicsui/web_client/stylesheets/popover/annotationPopover.styl
@@ -5,6 +5,7 @@
 
     .h-annotation-popover
         position absolute
+        width max-content
         max-width 400px
         background-color #fff
         z-index 200
@@ -46,6 +47,7 @@
             width 400px
 
         .h-annotation-name
+            white-space normal
             font-weight bold
 
         .h-annotation-creator, .h-annotation-created


### PR DESCRIPTION
Changes style settings so long annotation label titles no longer overflow outside of the popover, but wrap to the next line instead.

Closes #177 