### PR TITLE
Add feature to zoom to highlighted annotations in 'Interactive Mode'

### DIFF
--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -227,8 +227,6 @@ var DrawWidget = Panel.extend({
             min: Number.NEGATIVE_INFINITY,
             max: Number.POSITIVE_INFINITY,
         });
-        map.clampBoundsX(false);
-        map.clampBoundsY(false);
         const newView = pointAnnot ? {
             center: {
                 x: bounds.left,

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -209,12 +209,8 @@ var DrawWidget = Panel.extend({
                 points = convertCircle(annot.attributes).coordinates[0];
                 break;
         }
-        const xCoords = points.map((point) => {
-            return point[0];
-        });
-        const yCoords = points.map((point) => {
-            return point[1];
-        });
+        const xCoords = points.map((point) => point[0]);
+        const yCoords = points.map((point) => point[1]);
         const bounds = {
             left: Math.min(...xCoords),
             top: Math.min(...yCoords),

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -483,8 +483,9 @@ var DrawWidget = Panel.extend({
         this.parentView.trigger('h:highlightAnnotation', this.annotation.id, id);
     },
 
-    _unhighlightElement() {
-        this.parentView.trigger('h:highlightAnnotation');
+    _unhighlightElement(evt) {
+        const id = $(evt.currentTarget).data('id');
+        this.parentView.trigger('h:highlightAnnotation', false, id);
     },
 
     _recalculateGroupAggregation() {

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -223,15 +223,15 @@ var DrawWidget = Panel.extend({
             min: Number.NEGATIVE_INFINITY,
             max: Number.POSITIVE_INFINITY
         });
-        const newView = pointAnnot ?
-                        {
-                            center: {
-                                x: bounds.left,
-                                y: bounds.top
-                            },
-                        zoom: false
-                        } :
-                        map.zoomAndCenterFromBounds(bounds, map.rotation());
+        const newView = pointAnnot
+            ? {
+                center: {
+                    x: bounds.left,
+                    y: bounds.top
+                },
+                zoom: false
+            }
+            : map.zoomAndCenterFromBounds(bounds, map.rotation());
         map.zoomRange({
             min: originalZoomRange.origMin,
             max: originalZoomRange.max

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -47,7 +47,6 @@ var DrawWidget = Panel.extend({
         this.collection = this.annotation.elements();
         this.viewer = settings.viewer;
         this.setViewer(settings.viewer);
-        this.setZoomWidget(settings.zoomWidget);
         this.setAnnotationSelector(settings.annotationSelector);
         this._drawingType = settings.drawingType || null;
 
@@ -160,14 +159,6 @@ var DrawWidget = Panel.extend({
     },
 
     /**
-     * Set the image 'zoomWidget' instance.
-     */
-    setZoomWidget(zoomWidget) {
-        this.zoomWidget = zoomWidget;
-        return this;
-    },
-
-    /**
      * Set the image 'annotationSelector' instance.
      */
     setAnnotationSelector(annotationSelector) {
@@ -241,20 +232,18 @@ var DrawWidget = Panel.extend({
                             center: {
                                 x: bounds.left,
                                 y: bounds.top
-                        },
+                            },
                         zoom: false
                         } :
                         map.zoomAndCenterFromBounds(bounds, map.rotation());
         map.zoomRange(originalZoomRange);
-        if (Math.abs(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666 - this.zoomWidget.zoomToMagnification(map.zoom())) <= 40 && map.zoom() < newView.zoom) {
+        if (Math.abs(newView.zoom - 1.5 - map.zoom()) <= 0.5 && map.zoom() < newView.zoom) {
             newView.zoom = false;
         }
         map.transition({
             center: newView.center,
             duration: ((newView.center.x - map.center().x) ** 2 + (newView.center.y - map.center().y) ** 2) ** 0.5,
-            zoom: newView.zoom === false ?
-                map.zoom() :
-                this.zoomWidget.magnificationToZoom(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666)
+            zoom: newView.zoom === false ? map.zoom() : newView.zoom - 1.5
         });
         this._skipRenderHTML = true;
     },

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -213,6 +213,11 @@ var DrawWidget = Panel.extend({
             bottom: Math.max(... yCoords)
         }
         const map = this.parentView.viewer;
+        const originalZoomRange = map.zoomRange();
+        map.zoomRange({
+            min: Number.NEGATIVE_INFINITY,
+            max: Number.POSITIVE_INFINITY,
+        });
         map.clampBoundsX(false);
         map.clampBoundsY(false);
         const newView = pointAnnot ? {
@@ -221,6 +226,7 @@ var DrawWidget = Panel.extend({
                 y: bounds.top
             },
         } : map.zoomAndCenterFromBounds(bounds, map.rotation());
+        map.zoomRange(originalZoomRange);
         map.transition({
             center: newView.center,
             duration: ((newView.center.x-map.center().x)**2+(newView.center.y-map.center().y)**2)**0.5,

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -489,7 +489,8 @@ var DrawWidget = Panel.extend({
 
     _highlightElement(evt) {
         const id = $(evt.currentTarget).data('id');
-        if (this.annotationSelector._interactiveMode) {
+        const annotType = this.collection._byId[id].get('type');
+        if (this.annotationSelector._interactiveMode && ['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(annotType)) {
             $(evt.currentTarget).find('.h-view-element').show();
         }
         this.parentView.trigger('h:highlightAnnotation', this.annotation.id, id);

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -240,13 +240,17 @@ var DrawWidget = Panel.extend({
             center: {
                 x: bounds.left,
                 y: bounds.top
-            }
+            },
+            zoom: false
         } : map.zoomAndCenterFromBounds(bounds, map.rotation());
         map.zoomRange(originalZoomRange);
+        if (Math.abs(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666 - this.zoomWidget.zoomToMagnification(map.zoom())) <= 40 && map.zoom() < newView.zoom) {
+            newView.zoom = false;
+        }
         map.transition({
             center: newView.center,
             duration: ((newView.center.x - map.center().x) ** 2 + (newView.center.y - map.center().y) ** 2) ** 0.5,
-            zoom: pointAnnot ?
+            zoom: newView.zoom === false ?
                   map.zoom() :
                   this.zoomWidget.magnificationToZoom(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666)
         });

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -236,13 +236,15 @@ var DrawWidget = Panel.extend({
             min: Number.NEGATIVE_INFINITY,
             max: Number.POSITIVE_INFINITY
         });
-        const newView = pointAnnot ? {
-            center: {
-                x: bounds.left,
-                y: bounds.top
-            },
-            zoom: false
-        } : map.zoomAndCenterFromBounds(bounds, map.rotation());
+        const newView = pointAnnot ?
+                        {
+                            center: {
+                                x: bounds.left,
+                                y: bounds.top
+                        },
+                        zoom: false
+                        } :
+                        map.zoomAndCenterFromBounds(bounds, map.rotation());
         map.zoomRange(originalZoomRange);
         if (Math.abs(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666 - this.zoomWidget.zoomToMagnification(map.zoom())) <= 40 && map.zoom() < newView.zoom) {
             newView.zoom = false;
@@ -251,8 +253,8 @@ var DrawWidget = Panel.extend({
             center: newView.center,
             duration: ((newView.center.x - map.center().x) ** 2 + (newView.center.y - map.center().y) ** 2) ** 0.5,
             zoom: newView.zoom === false ?
-                  map.zoom() :
-                  this.zoomWidget.magnificationToZoom(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666)
+                map.zoom() :
+                this.zoomWidget.magnificationToZoom(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666)
         });
         this._skipRenderHTML = true;
     },

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -232,7 +232,10 @@ var DrawWidget = Panel.extend({
                         zoom: false
                         } :
                         map.zoomAndCenterFromBounds(bounds, map.rotation());
-        map.zoomRange(originalZoomRange);
+        map.zoomRange({
+            min: originalZoomRange.origMin,
+            max: originalZoomRange.max
+        });
         if (Math.abs(newView.zoom - 1.5 - map.zoom()) <= 0.5 && map.zoom() < newView.zoom) {
             newView.zoom = false;
         }

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -194,7 +194,7 @@ var DrawWidget = Panel.extend({
         switch (annot.get('type')) {
             case 'point':
                 points = [annot.get('center')];
-                pointAnnot = true
+                pointAnnot = true;
                 break;
             case 'polyline':
                 points = annot.get('points');
@@ -210,34 +210,36 @@ var DrawWidget = Panel.extend({
                 break;
         }
         const xCoords = points.map((point) => {
-            return point[0]
+            return point[0];
         });
         const yCoords = points.map((point) => {
-            return point[1]
+            return point[1];
         });
         const bounds = {
-            left: Math.min(... xCoords),
-            top: Math.min(... yCoords),
-            right: Math.max(... xCoords),
-            bottom: Math.max(... yCoords)
-        }
+            left: Math.min(...xCoords),
+            top: Math.min(...yCoords),
+            right: Math.max(...xCoords),
+            bottom: Math.max(...yCoords)
+        };
         const map = this.parentView.viewer;
         const originalZoomRange = map.zoomRange();
         map.zoomRange({
             min: Number.NEGATIVE_INFINITY,
-            max: Number.POSITIVE_INFINITY,
+            max: Number.POSITIVE_INFINITY
         });
         const newView = pointAnnot ? {
             center: {
                 x: bounds.left,
                 y: bounds.top
-            },
+            }
         } : map.zoomAndCenterFromBounds(bounds, map.rotation());
         map.zoomRange(originalZoomRange);
         map.transition({
             center: newView.center,
-            duration: ((newView.center.x-map.center().x)**2+(newView.center.y-map.center().y)**2)**0.5,
-            zoom: pointAnnot ? map.zoom() : this.zoomWidget.magnificationToZoom(this.zoomWidget.zoomToMagnification(newView.zoom)*0.2968 + 1.8666),
+            duration: ((newView.center.x - map.center().x) ** 2 + (newView.center.y - map.center().y) ** 2) ** 0.5,
+            zoom: pointAnnot ?
+                  map.zoom() :
+                  this.zoomWidget.magnificationToZoom(this.zoomWidget.zoomToMagnification(newView.zoom) * 0.2968 + 1.8666)
         });
         this._skipRenderHTML = true;
     },

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -47,6 +47,7 @@ var DrawWidget = Panel.extend({
         this.collection = this.annotation.elements();
         this.viewer = settings.viewer;
         this.setViewer(settings.viewer);
+        this.setZoomWidget(settings.zoomWidget);
         this._drawingType = settings.drawingType || null;
 
         this._highlighted = {};
@@ -158,6 +159,14 @@ var DrawWidget = Panel.extend({
     },
 
     /**
+     * Set the image 'zoomWidget' instance.
+     */
+    setZoomWidget(zoomWidget) {
+        this.zoomWidget = zoomWidget;
+        return this;
+    },
+
+    /**
      * Respond to a click on the "edit" button by rendering
      * the EditAnnotation modal dialog.
      */
@@ -230,7 +239,7 @@ var DrawWidget = Panel.extend({
         map.transition({
             center: newView.center,
             duration: ((newView.center.x-map.center().x)**2+(newView.center.y-map.center().y)**2)**0.5,
-            zoom: pointAnnot ? map.zoom() : (newView.zoom > 0 ? newView.zoom*0.4 : newView.zoom*2.5),
+            zoom: pointAnnot ? map.zoom() : this.zoomWidget.magnificationToZoom(this.zoomWidget.zoomToMagnification(newView.zoom)*0.2968 + 1.8666),
         });
         this._skipRenderHTML = true;
     },

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -48,6 +48,7 @@ var DrawWidget = Panel.extend({
         this.viewer = settings.viewer;
         this.setViewer(settings.viewer);
         this.setZoomWidget(settings.zoomWidget);
+        this.setAnnotationSelector(settings.annotationSelector);
         this._drawingType = settings.drawingType || null;
 
         this._highlighted = {};
@@ -163,6 +164,14 @@ var DrawWidget = Panel.extend({
      */
     setZoomWidget(zoomWidget) {
         this.zoomWidget = zoomWidget;
+        return this;
+    },
+
+    /**
+     * Set the image 'annotationSelector' instance.
+     */
+    setAnnotationSelector(annotationSelector) {
+        this.annotationSelector = annotationSelector;
         return this;
     },
 
@@ -489,12 +498,15 @@ var DrawWidget = Panel.extend({
 
     _highlightElement(evt) {
         const id = $(evt.currentTarget).data('id');
+        if (this.annotationSelector._interactiveMode) {
+            $(evt.currentTarget).find('.h-view-element').show();
+        }
         this.parentView.trigger('h:highlightAnnotation', this.annotation.id, id);
     },
 
     _unhighlightElement(evt) {
-        const id = $(evt.currentTarget).data('id');
-        this.parentView.trigger('h:highlightAnnotation', false, id);
+        $(evt.currentTarget).find('.h-view-element').hide();
+        this.parentView.trigger('h:highlightAnnotation');
     },
 
     _recalculateGroupAggregation() {

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -239,10 +239,14 @@ var DrawWidget = Panel.extend({
         if (Math.abs(newView.zoom - 1.5 - map.zoom()) <= 0.5 && map.zoom() < newView.zoom) {
             newView.zoom = false;
         }
+        const distance = ((newView.center.x - map.center().x) ** 2 + (newView.center.y - map.center().y) ** 2) ** 0.5;
         map.transition({
             center: newView.center,
-            duration: ((newView.center.x - map.center().x) ** 2 + (newView.center.y - map.center().y) ** 2) ** 0.5,
-            zoom: newView.zoom === false ? map.zoom() : newView.zoom - 1.5
+            zoom: newView.zoom === false ? map.zoom() : newView.zoom - 1.5,
+            duration: Math.min(1000, Math.max(100, distance)),
+            endClamp: false,
+            interp: distance < 500 ? undefined : window.d3.interpolateZoom,
+            ease: window.d3.easeExpInOut
         });
         this._skipRenderHTML = true;
     },

--- a/histomicsui/web_client/stylesheets/panels/drawWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/drawWidget.styl
@@ -19,6 +19,9 @@
             max-width calc(100% - 50px)
             text-overflow ellipsis
 
+        .h-view-element
+            margin-left 3px
+
         .h-delete-element
             float right
 

--- a/histomicsui/web_client/stylesheets/panels/drawWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/drawWidget.styl
@@ -16,7 +16,7 @@
             overflow hidden
             display inline-block
             vertical-align top
-            max-width calc(100% - 50px)
+            max-width calc(100% - 75px)
             text-overflow ellipsis
 
         .h-view-element

--- a/histomicsui/web_client/stylesheets/panels/drawWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/drawWidget.styl
@@ -21,6 +21,7 @@
 
         .h-view-element
             margin-left 3px
+            display none
 
         .h-delete-element
             float right

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -6,4 +6,5 @@ if elements.length
     .h-element(data-id=element.id, class=classes)
       span.icon-cog.h-edit-element(title='Change style')
       span.h-element-label(title=label) #{label}
+      span.icon-zoom-in.h-view-element(title='View annotation')
       span.icon-cancel.h-delete-element(title='Remove')

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -283,8 +283,9 @@ var ImageView = View.extend({
                     this.drawWidget
                         .setViewer(this.viewerWidget)
                         .setElement('.h-draw-widget').render();
-                    if (this.annotationSelector.interactiveMode())
+                    if (this.annotationSelector.interactiveMode()) {
                         this.$('.h-draw-widget').find('.h-view-element').removeClass('hidden');
+                    }
                 }
                 this._orderPanels();
             });
@@ -300,8 +301,9 @@ var ImageView = View.extend({
                     .setViewer(null)
                     .setZoom(this.zoomWidget)
                     .setElement('.h-draw-widget').render();
-                if (this.annotationSelector.interactiveMode())
+                if (this.annotationSelector.interactiveMode()) {
                     this.$('.h-draw-widget').find('.h-view-element').removeClass('hidden');
+                }
             }
         }
         this.controlPanel.setElement('#h-analysis-panel').render();
@@ -649,11 +651,13 @@ var ImageView = View.extend({
         if (!this.annotationSelector.interactiveMode()) {
             return;
         }
+        // If it was a specific annotation that was highlighted, find that annotation's
+        // listing and toggle its zoom button to be hidden or unhidden
         if (element) {
-            $((this.$el.find('.h-element').toArray().filter(el => $(el).attr('data-id') === element))[0]).find('.h-view-element').toggle();
+            $((this.$el.find('.h-element').toArray().filter((el) => $(el).attr('data-id') === element))[0]).find('.h-view-element').toggle();
         }
         this._closeContextMenu();
-        this.viewerWidget.highlightAnnotation(annotation, annotation == false ? undefined : element);
+        this.viewerWidget.highlightAnnotation(annotation, annotation === false ? undefined : element);
     },
 
     widgetRegion(model) {

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -282,10 +282,8 @@ var ImageView = View.extend({
                     this.$('.h-draw-widget').removeClass('hidden');
                     this.drawWidget
                         .setViewer(this.viewerWidget)
+                        .setAnnotationSelector(this.annotationSelector)
                         .setElement('.h-draw-widget').render();
-                    if (this.annotationSelector.interactiveMode()) {
-                        this.$('.h-draw-widget').find('.h-view-element').removeClass('hidden');
-                    }
                 }
                 this._orderPanels();
             });
@@ -300,10 +298,8 @@ var ImageView = View.extend({
                 this.drawWidget
                     .setViewer(null)
                     .setZoom(this.zoomWidget)
+                    .setAnnotationSelector(this.annotationSelector)
                     .setElement('.h-draw-widget').render();
-                if (this.annotationSelector.interactiveMode()) {
-                    this.$('.h-draw-widget').find('.h-view-element').removeClass('hidden');
-                }
             }
         }
         this.controlPanel.setElement('#h-analysis-panel').render();
@@ -650,11 +646,6 @@ var ImageView = View.extend({
     _highlightAnnotationForInteractiveMode(annotation, element) {
         if (!this.annotationSelector.interactiveMode()) {
             return;
-        }
-        // If it was a specific annotation that was highlighted, find that annotation's
-        // listing and toggle its zoom button to be hidden or unhidden
-        if (element) {
-            $((this.$el.find('.h-element').toArray().filter((el) => $(el).attr('data-id') === element))[0]).find('.h-view-element').toggle();
         }
         this._closeContextMenu();
         this.viewerWidget.highlightAnnotation(annotation, annotation === false ? undefined : element);
@@ -1077,7 +1068,8 @@ var ImageView = View.extend({
                 drawingType: this._lastDrawingType,
                 el: this.$('.h-draw-widget'),
                 viewer: this.viewerWidget,
-                zoomWidget: this.zoomWidget
+                zoomWidget: this.zoomWidget,
+                annotationSelector: this.annotationSelector
             }).render();
             this.listenTo(this.drawWidget, 'h:redraw', this._redrawAnnotation);
             this.listenTo(this.drawWidget, 'h:styleGroupsUpdated', this._updatePixelmapsWithCategories);

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -282,6 +282,7 @@ var ImageView = View.extend({
                     this.$('.h-draw-widget').removeClass('hidden');
                     this.drawWidget
                         .setViewer(this.viewerWidget)
+                        .setZoom(this.zoomWidget)
                         .setAnnotationSelector(this.annotationSelector)
                         .setElement('.h-draw-widget').render();
                 }

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -283,6 +283,8 @@ var ImageView = View.extend({
                     this.drawWidget
                         .setViewer(this.viewerWidget)
                         .setElement('.h-draw-widget').render();
+                    if (this.annotationSelector.interactiveMode())
+                        this.$('.h-draw-widget').find('.h-view-element').removeClass('hidden');
                 }
                 this._orderPanels();
             });
@@ -297,6 +299,8 @@ var ImageView = View.extend({
                 this.drawWidget
                     .setViewer(null)
                     .setElement('.h-draw-widget').render();
+                if (this.annotationSelector.interactiveMode())
+                    this.$('.h-draw-widget').find('.h-view-element').removeClass('hidden');
             }
         }
         this.controlPanel.setElement('#h-analysis-panel').render();
@@ -644,8 +648,11 @@ var ImageView = View.extend({
         if (!this.annotationSelector.interactiveMode()) {
             return;
         }
+        if (element) {
+            $((this.$el.find('.h-element').toArray().filter(el => $(el).attr('data-id') === element))[0]).find('.h-view-element').toggle();
+        }
         this._closeContextMenu();
-        this.viewerWidget.highlightAnnotation(annotation, element);
+        this.viewerWidget.highlightAnnotation(annotation, annotation == false ? undefined : element);
     },
 
     widgetRegion(model) {

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -282,7 +282,6 @@ var ImageView = View.extend({
                     this.$('.h-draw-widget').removeClass('hidden');
                     this.drawWidget
                         .setViewer(this.viewerWidget)
-                        .setZoom(this.zoomWidget)
                         .setAnnotationSelector(this.annotationSelector)
                         .setElement('.h-draw-widget').render();
                 }
@@ -298,7 +297,6 @@ var ImageView = View.extend({
                 this.$('.h-draw-widget').removeClass('hidden');
                 this.drawWidget
                     .setViewer(null)
-                    .setZoom(this.zoomWidget)
                     .setAnnotationSelector(this.annotationSelector)
                     .setElement('.h-draw-widget').render();
             }
@@ -1069,7 +1067,6 @@ var ImageView = View.extend({
                 drawingType: this._lastDrawingType,
                 el: this.$('.h-draw-widget'),
                 viewer: this.viewerWidget,
-                zoomWidget: this.zoomWidget,
                 annotationSelector: this.annotationSelector
             }).render();
             this.listenTo(this.drawWidget, 'h:redraw', this._redrawAnnotation);

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -298,6 +298,7 @@ var ImageView = View.extend({
                 this.$('.h-draw-widget').removeClass('hidden');
                 this.drawWidget
                     .setViewer(null)
+                    .setZoom(this.zoomWidget)
                     .setElement('.h-draw-widget').render();
                 if (this.annotationSelector.interactiveMode())
                     this.$('.h-draw-widget').find('.h-view-element').removeClass('hidden');
@@ -1071,7 +1072,8 @@ var ImageView = View.extend({
                 annotation: this.activeAnnotation,
                 drawingType: this._lastDrawingType,
                 el: this.$('.h-draw-widget'),
-                viewer: this.viewerWidget
+                viewer: this.viewerWidget,
+                zoomWidget: this.zoomWidget
             }).render();
             this.listenTo(this.drawWidget, 'h:redraw', this._redrawAnnotation);
             this.listenTo(this.drawWidget, 'h:styleGroupsUpdated', this._updatePixelmapsWithCategories);


### PR DESCRIPTION
Adds a new button in 'Interactive Mode' which centers the highlighted annotation on screen by changing the image viewer's zoom and location.  It appears next to an annotation's type when it is moused over in the list.

Closes #33 