### PR TITLE
Add brush controls

### DIFF
--- a/histomicsui/web_client/stylesheets/panels/drawWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/drawWidget.styl
@@ -40,6 +40,9 @@
     .btn-group-sm>.btn
       padding-left 3px
       padding-right 7px
+    .btn-group-sm>.btn.h-brush-dropdown
+      padding-left 0
+      padding-right 0
 
   .h-style-group-row
     margin 10px 0
@@ -58,6 +61,42 @@
     white-space nowrap
     text-overflow ellipsis
     font-weight normal
+
+  button[data-type="brush"]
+    span.shape
+      display none
+  button[data-type="brush"][shape="square"]
+    span.shape
+      &.square
+        display inline
+  button[data-type="brush"][shape="circle"]
+    span.shape
+      &.circle
+        display inline
+
+  .h-dropdown-title i
+    pointer-events none
+  .h-dropdown-content
+    position absolute
+    background white
+    border 2px solid black
+    border-radius 5px
+    right 0
+    top 30px
+    padding 5px 10px
+    .form-group
+      margin-bottom 0
+      padding 0
+      input[type="radio"]
+        margin-top 2px
+      input[type="number"]
+        margin-left 5px
+      input[type="checkbox"]
+        margin-right 5px
+  .h-brush-controls
+    width 165px
+  .h-brush-size
+    width 60px
 
 .flattenicon:before
   transform: scale(1, 0.67)

--- a/histomicsui/web_client/templates/panels/drawWidget.pug
+++ b/histomicsui/web_client/templates/panels/drawWidget.pug
@@ -37,6 +37,31 @@ block content
       button.h-draw.btn.btn-default(
         type='button', data-type='line', title='Draw a new line (keyboard shortcut: l)', class=drawingType === 'line' ? 'active' : null)
         | #[span.icon-pencil]Line
-
+    .btn-group.btn-group-sm
+      button.h-draw.btn.btn-default(
+        type='button', data-type='brush', title='Draw with a brush (keyboard shortcut: b)', class=drawingType === 'brush' ? 'active' : null, shape=opts.brush_shape)
+        span.shape.square
+          | #[span.icon-check-empty]
+        span.shape.circle
+          | #[span.icon-circle-empty]
+        | Brush
+      button.btn.btn-default.h-dropdown-title.h-brush-dropdown(type='button', data-target='#h-brush-controls')
+        i.icon-down-open
+      .h-brush-controls.h-dropdown-content.collapse
+        .form-group.input-sm
+          label.radio-inline
+            input.h-brush-shape.h-brush-square(type="radio", name="h-brush-shape", checked=opts.brush_shape !== 'circle' ? 'checked' : undefined, shape="square", next_shape="circle")
+            | Square
+          label.radio-inline
+            input.h-brush-shape.h-brush-circle(type="radio", name="h-brush-shape", checked=opts.brush_shape === 'circle' ? 'checked' : undefined, shape="circle", next_shape="square")
+            | Circle
+        .form-group.input-sm
+          label
+            | Size
+            input.h-brush-size(type="number", min="1", value=opts.brush_size)
+        .form-group.input-sm
+          label(title="If checked, the size is in screen pixels.  If unchecked, the size is in base image pixels")
+            input.h-brush-screen(type="checkbox", checked=opts.brush_screen ? 'checked' : undefined)
+            | Screen
   .h-elements-container
     include drawWidgetElement.pug

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -1094,6 +1094,15 @@ var ImageView = View.extend({
         if (/^(input|textarea|select)$/.test((document.activeElement.tagName || '').toLowerCase())) {
             return;
         }
+        const drawModes = {
+            o: 'point',
+            r: 'rectangle',
+            i: 'ellipse',
+            c: 'circle',
+            p: 'polygon',
+            l: 'line',
+            b: 'brush'
+        };
         switch (evt.key) {
             case 'a':
                 this._showOrHideAnnotations();
@@ -1111,58 +1120,19 @@ var ImageView = View.extend({
             case ' ': // pressing space bar creates a new annotation
                 this.annotationSelector.createAnnotation();
                 break;
-            case 'o':
+            case 'B':
                 if (this.activeAnnotation) {
-                    if (this.drawWidget._drawingType === 'point') {
-                        this.drawWidget.cancelDrawMode();
-                    } else {
-                        this.drawWidget.drawElement(undefined, 'point');
-                    }
+                    this.drawWidget.nextBrushShape();
                 }
                 break;
-            case 'r':
+            case 'x':
                 if (this.activeAnnotation) {
-                    if (this.drawWidget._drawingType === 'rectangle') {
-                        this.drawWidget.cancelDrawMode();
-                    } else {
-                        this.drawWidget.drawElement(undefined, 'rectangle');
-                    }
+                    this.drawWidget.adjustBrushSize(1);
                 }
                 break;
-            case 'i':
+            case 'z':
                 if (this.activeAnnotation) {
-                    if (this.drawWidget._drawingType === 'ellipse') {
-                        this.drawWidget.cancelDrawMode();
-                    } else {
-                        this.drawWidget.drawElement(undefined, 'ellipse');
-                    }
-                }
-                break;
-            case 'c':
-                if (this.activeAnnotation) {
-                    if (this.drawWidget._drawingType === 'circle') {
-                        this.drawWidget.cancelDrawMode();
-                    } else {
-                        this.drawWidget.drawElement(undefined, 'circle');
-                    }
-                }
-                break;
-            case 'p':
-                if (this.activeAnnotation) {
-                    if (this.drawWidget._drawingType === 'polygon') {
-                        this.drawWidget.cancelDrawMode();
-                    } else {
-                        this.drawWidget.drawElement(undefined, 'polygon');
-                    }
-                }
-                break;
-            case 'l':
-                if (this.activeAnnotation) {
-                    if (this.drawWidget._drawingType === 'line') {
-                        this.drawWidget.cancelDrawMode();
-                    } else {
-                        this.drawWidget.drawElement(undefined, 'line');
-                    }
+                    this.drawWidget.adjustBrushSize(-1);
                 }
                 break;
             case 'q':
@@ -1176,7 +1146,7 @@ var ImageView = View.extend({
                 }
                 break;
             case 'Enter':
-                const drawingType = this.drawWidget._drawingType;
+                const drawingType = this.drawWidget && this.drawWidget._drawingType;
                 if (this.activeAnnotation && ['polygon', 'line'].includes(drawingType)) {
                     const annotation = this.viewerWidget.annotationLayer.annotations()[0];
 
@@ -1195,6 +1165,17 @@ var ImageView = View.extend({
 
                     this.drawWidget.cancelDrawMode();
                 }
+                break;
+            default:
+                if (this.drawWidget && drawModes[evt.key] && this.activeAnnotation) {
+                    let mode = drawModes[evt.key];
+                    if (this.drawWidget._drawingType === mode) {
+                        this.drawWidget.cancelDrawMode();
+                    } else {
+                        this.drawWidget.drawElement(undefined, mode);
+                    }
+                }
+                break;
         }
     },
 


### PR DESCRIPTION
Closes #147.

Closes #141.  The current style group and brush settings are stored in local storage.

Currently, circle and ellipse annotations are converted to polygons when they are combined in some manner.  This could be done in a coarser manner to reduce the number of vertices.  The current setting is no more than 1/10th of a pixel of error at the maximum zoom level (typically this is twice the resolution of the base image, so 1/20th of a base image pixel, though that can be increased).  Perhaps something like 1/2 of a base pixel would be sufficient and speed up some of the processes.

Also, this currently becomes slow with a large number of annotation elements because it updates the entire annotation feature.  To speed this up, we probably would need to render the annotation as two sets of features (unchanged and recently changed), but that would involve more book-keeping.  Once this is in use, we'll see where the limit of performance is located and adjust accordingly.