### PR TITLE
Pin vue and vue-template-compiler.

### DIFF
--- a/histomicsui/web_client/package.json
+++ b/histomicsui/web_client/package.json
@@ -38,9 +38,9 @@
         "sinon": "^2.1.0",
         "tinycolor2": "^1.4.1",
         "url-search-params-polyfill": "^8.1.1",
-        "vue": "^2.6.14",
-        "vue-template-compiler": "^2.6.14",
-        "vue-loader": "^15.9.8",
+        "vue": "~2.6.14",
+        "vue-template-compiler": "~2.6.14",
+        "vue-loader": "~15.9.8",
         "vue-color": "^2.8.1",
         "webpack": "^2.7.0"
     },


### PR DESCRIPTION
The latest vue 2.x, vue-template-compiler, and vue-loader aren't working with the rest of our stack.

@naglepuff I'm merging this, but if you can take a look at how we can unpin this, I'd appreciate it.