### PR TITLE
Add optional help button

### DIFF
--- a/histomicsui/__init__.py
+++ b/histomicsui/__init__.py
@@ -157,11 +157,10 @@ SettingDefault.defaults.update({
 
 @setting_utilities.validator({
     PluginSettings.HUI_HELP_URL,
-    PluginSettings.HUI_HELP_TOOLTIP,
+    PluginSettings.HUI_HELP_TOOLTIP
 })
 def validateHistomicsUIHelp(doc):
-    if not doc['value']:
-        doc['value'] = False
+    pass
 
 @setting_utilities.validator({
     PluginSettings.HUI_DELETE_ANNOTATIONS_AFTER_INGEST,

--- a/histomicsui/__init__.py
+++ b/histomicsui/__init__.py
@@ -153,13 +153,15 @@ SettingDefault.defaults.update({
     PluginSettings.HUI_BRAND_COLOR: '#777777',
     PluginSettings.HUI_HELP_URL:
         'https://github.com/DigitalSlideArchive/HistomicsUI/blob/master/docs/controls.rst',
-    PluginSettings.HUI_HELP_TOOLTIP: 'Mouse and keyboard controls'
+    PluginSettings.HUI_HELP_TOOLTIP: 'Mouse and keyboard controls',
+    PluginSettings.HUI_HELP_TEXT: 'Help'
 })
 
 
 @setting_utilities.validator({
     PluginSettings.HUI_HELP_URL,
-    PluginSettings.HUI_HELP_TOOLTIP
+    PluginSettings.HUI_HELP_TOOLTIP,
+    PluginSettings.HUI_HELP_TEXT
 })
 def validateHistomicsUIHelp(doc):
     pass
@@ -212,6 +214,7 @@ class WebrootHistomicsUI(Webroot):
             'huiBannerColor': Setting().get(PluginSettings.HUI_BANNER_COLOR),
             'huiHelpURL': Setting().get(PluginSettings.HUI_HELP_URL),
             'huiHelpTooltip': Setting().get(PluginSettings.HUI_HELP_TOOLTIP),
+            'huiHelpText': Setting().get(PluginSettings.HUI_HELP_TEXT)
         })
         return super()._renderHTML()
 

--- a/histomicsui/__init__.py
+++ b/histomicsui/__init__.py
@@ -151,9 +151,11 @@ SettingDefault.defaults.update({
     PluginSettings.HUI_BRAND_NAME: 'HistomicsUI',
     PluginSettings.HUI_BANNER_COLOR: '#f8f8f8',
     PluginSettings.HUI_BRAND_COLOR: '#777777',
-    PluginSettings.HUI_HELP_URL: 'https://github.com/DigitalSlideArchive/HistomicsUI/blob/master/docs/controls.rst',
+    PluginSettings.HUI_HELP_URL:
+        'https://github.com/DigitalSlideArchive/HistomicsUI/blob/master/docs/controls.rst',
     PluginSettings.HUI_HELP_TOOLTIP: 'See viewing and editing controls'
 })
+
 
 @setting_utilities.validator({
     PluginSettings.HUI_HELP_URL,
@@ -161,6 +163,7 @@ SettingDefault.defaults.update({
 })
 def validateHistomicsUIHelp(doc):
     pass
+
 
 @setting_utilities.validator({
     PluginSettings.HUI_DELETE_ANNOTATIONS_AFTER_INGEST,

--- a/histomicsui/__init__.py
+++ b/histomicsui/__init__.py
@@ -153,7 +153,7 @@ SettingDefault.defaults.update({
     PluginSettings.HUI_BRAND_COLOR: '#777777',
     PluginSettings.HUI_HELP_URL:
         'https://github.com/DigitalSlideArchive/HistomicsUI/blob/master/docs/controls.rst',
-    PluginSettings.HUI_HELP_TOOLTIP: 'See viewing and editing controls'
+    PluginSettings.HUI_HELP_TOOLTIP: 'Mouse and keyboard controls'
 })
 
 

--- a/histomicsui/__init__.py
+++ b/histomicsui/__init__.py
@@ -151,8 +151,17 @@ SettingDefault.defaults.update({
     PluginSettings.HUI_BRAND_NAME: 'HistomicsUI',
     PluginSettings.HUI_BANNER_COLOR: '#f8f8f8',
     PluginSettings.HUI_BRAND_COLOR: '#777777',
+    PluginSettings.HUI_HELP_URL: 'https://github.com/DigitalSlideArchive/HistomicsUI/blob/master/docs/controls.rst',
+    PluginSettings.HUI_HELP_TOOLTIP: 'See viewing and editing controls'
 })
 
+@setting_utilities.validator({
+    PluginSettings.HUI_HELP_URL,
+    PluginSettings.HUI_HELP_TOOLTIP,
+})
+def validateHistomicsUIHelp(doc):
+    if not doc['value']:
+        doc['value'] = False
 
 @setting_utilities.validator({
     PluginSettings.HUI_DELETE_ANNOTATIONS_AFTER_INGEST,
@@ -199,6 +208,8 @@ class WebrootHistomicsUI(Webroot):
             'huiBrandName': Setting().get(PluginSettings.HUI_BRAND_NAME),
             'huiBrandColor': Setting().get(PluginSettings.HUI_BRAND_COLOR),
             'huiBannerColor': Setting().get(PluginSettings.HUI_BANNER_COLOR),
+            'huiHelpURL': Setting().get(PluginSettings.HUI_HELP_URL),
+            'huiHelpTooltip': Setting().get(PluginSettings.HUI_HELP_TOOLTIP),
         })
         return super()._renderHTML()
 

--- a/histomicsui/constants.py
+++ b/histomicsui/constants.py
@@ -16,3 +16,5 @@ class PluginSettings:
     HUI_BANNER_COLOR = 'histomicsui.banner_color'
     HUI_QUARANTINE_FOLDER = 'histomicsui.quarantine_folder'
     HUI_DELETE_ANNOTATIONS_AFTER_INGEST = 'histomicsui.delete_annotations_after_ingest'
+    HUI_HELP_URL = 'histomicsui.help_url'
+    HUI_HELP_TOOLTIP = 'histomicsui.help_tooltip'

--- a/histomicsui/constants.py
+++ b/histomicsui/constants.py
@@ -18,3 +18,4 @@ class PluginSettings:
     HUI_DELETE_ANNOTATIONS_AFTER_INGEST = 'histomicsui.delete_annotations_after_ingest'
     HUI_HELP_URL = 'histomicsui.help_url'
     HUI_HELP_TOOLTIP = 'histomicsui.help_tooltip'
+    HUI_HELP_TEXT = 'histomicsui.help_text'

--- a/histomicsui/web_client/stylesheets/body/configView.styl
+++ b/histomicsui/web_client/stylesheets/body/configView.styl
@@ -7,7 +7,11 @@
   display inline
   max-width 160px
 
-#g-hui-banner-default-color, #g-hui-brand-default-color
+#g-hui-help-url, #g-hui-help-tooltip
+  display inline-block
+  width calc(100% - 65px)
+
+#g-hui-banner-default-color, #g-hui-brand-default-color, #g-hui-help-default-url, #g-hui-help-default-tooltip
   width 65px
   display inline
   // Vertical-align is useful to avoid an 5px offset in Mozilla

--- a/histomicsui/web_client/stylesheets/body/configView.styl
+++ b/histomicsui/web_client/stylesheets/body/configView.styl
@@ -7,11 +7,12 @@
   display inline
   max-width 160px
 
-#g-hui-help-url, #g-hui-help-tooltip
+#g-hui-help-url, #g-hui-help-tooltip, #g-hui-help-text
   display inline-block
   width calc(100% - 65px)
 
-#g-hui-banner-default-color, #g-hui-brand-default-color, #g-hui-help-default-url, #g-hui-help-default-tooltip
+#g-hui-banner-default-color, #g-hui-brand-default-color, #g-hui-help-default-url,
+#g-hui-help-default-tooltip, #g-hui-help-default-text
   width 65px
   display inline
   // Vertical-align is useful to avoid an 5px offset in Mozilla

--- a/histomicsui/web_client/stylesheets/layout/header.styl
+++ b/histomicsui/web_client/stylesheets/layout/header.styl
@@ -7,6 +7,8 @@
       .h-image-menu-wrapper
         display inline
         float right
+    .h-help-button
+      padding 15px 7px
     z-index 1000
   @media (min-width: 768px)
     .navbar-right

--- a/histomicsui/web_client/templates/body/configView.pug
+++ b/histomicsui/web_client/templates/body/configView.pug
@@ -42,12 +42,20 @@ form#g-hui-form(role="form")
   .form-group
     label(for="g-hui-help-tooltip") Help Tooltip
     #g-hui-help-tooltip-container
-      input#g-hui-help-tooltip.form-control.input-sm(
-          type="text", value=settings['histomicsui.help_tooltip'],
-          placeholder="The text for the help button's tooltip"
-          title="The tooltip text for the optional help buttion in the application.")
-      button#g-hui-help-default-tooltip.form-control.input-sm(
-          type="button", title="Default text") default
+      - if (settings['histomicsui.help_url'].trim() == '')
+        input#g-hui-help-tooltip.form-control.input-sm(
+            type="text", value=settings['histomicsui.help_tooltip'],
+            placeholder="The text for the help button's tooltip", disabled
+            title="The tooltip text for the optional help buttion in the application.")
+        button#g-hui-help-default-tooltip.form-control.input-sm(
+            type="button", title="Default text", disabled) default
+      - else
+        input#g-hui-help-tooltip.form-control.input-sm(
+            type="text", value=settings['histomicsui.help_tooltip'],
+            placeholder="The text for the help button's tooltip"
+            title="The tooltip text for the optional help buttion in the application.")
+        button#g-hui-help-default-tooltip.form-control.input-sm(
+            type="button", title="Default text") default
   .form-group
     label
       | Default styles for drawing annotations

--- a/histomicsui/web_client/templates/body/configView.pug
+++ b/histomicsui/web_client/templates/body/configView.pug
@@ -34,14 +34,20 @@ form#g-hui-form(role="form")
     label(for="g-hui-help-url") Help URL
     #g-hui-help-url-container
       input#g-hui-help-url.form-control.input-sm(
-          type="text", value=settings['histomicsui.help_url'] || defaults['histomicsui.help_url'],
-          title="The link for the optional help button in the application.")
+          type="text", value=settings['histomicsui.help_url'],
+          placeholder="(Optional) A URL to direct users to to provide help"
+          title="The link that the optional help button in the application should lead to.  If no URL is specified, the help button won't be displayed.")
+      button#g-hui-help-default-url.form-control.input-sm(
+          type="button", title="Default URL") default
   .form-group
     label(for="g-hui-help-tooltip") Help Tooltip
     #g-hui-help-tooltip-container
       input#g-hui-help-tooltip.form-control.input-sm(
-          type="text", value=settings['histomicsui.help_tooltip'] || defaults['histomicsui.help_tooltip'],
+          type="text", value=settings['histomicsui.help_tooltip'],
+          placeholder="The text for the help button's tooltip"
           title="The tooltip text for the optional help buttion in the application.")
+      button#g-hui-help-default-tooltip.form-control.input-sm(
+          type="button", title="Default text") default
   .form-group
     label
       | Default styles for drawing annotations

--- a/histomicsui/web_client/templates/body/configView.pug
+++ b/histomicsui/web_client/templates/body/configView.pug
@@ -42,20 +42,20 @@ form#g-hui-form(role="form")
   .form-group
     label(for="g-hui-help-tooltip") Help Tooltip
     #g-hui-help-tooltip-container
-      - if (settings['histomicsui.help_url'].trim() == '')
-        input#g-hui-help-tooltip.form-control.input-sm(
-            type="text", value=settings['histomicsui.help_tooltip'],
-            placeholder="The text for the help button's tooltip", disabled,
-            title="The tooltip text for the optional help buttion in the application.")
-        button#g-hui-help-default-tooltip.form-control.input-sm(
-            type="button", title="Default text", disabled) default
-      - else
+      if settings['histomicsui.help_url'].trim()
         input#g-hui-help-tooltip.form-control.input-sm(
             type="text", value=settings['histomicsui.help_tooltip'],
             placeholder="The text for the help button's tooltip",
             title="The tooltip text for the optional help buttion in the application.")
         button#g-hui-help-default-tooltip.form-control.input-sm(
             type="button", title="Default text") default
+      else
+        input#g-hui-help-tooltip.form-control.input-sm(
+            type="text", value=settings['histomicsui.help_tooltip'],
+            placeholder="The text for the help button's tooltip", disabled,
+            title="The tooltip text for the optional help buttion in the application.")
+        button#g-hui-help-default-tooltip.form-control.input-sm(
+            type="button", title="Default text", disabled) default
   .form-group
     label
       | Default styles for drawing annotations

--- a/histomicsui/web_client/templates/body/configView.pug
+++ b/histomicsui/web_client/templates/body/configView.pug
@@ -40,22 +40,23 @@ form#g-hui-form(role="form")
       button#g-hui-help-default-url.form-control.input-sm(
           type="button", title="Default URL") default
   .form-group
+    label(for="g-hui-help-text") Help Text
+    #g-hui-help-text-container
+      input#g-hui-help-text.form-control.input-sm(
+          type="text", value=settings['histomicsui.help_text'],
+          placeholder="The text to display with the help button",
+          title="The text for the optional help buttion in the application.")
+      button#g-hui-help-default-text.form-control.input-sm(
+          type="button", title="Default text") default
+  .form-group
     label(for="g-hui-help-tooltip") Help Tooltip
     #g-hui-help-tooltip-container
-      if settings['histomicsui.help_url'].trim()
-        input#g-hui-help-tooltip.form-control.input-sm(
-            type="text", value=settings['histomicsui.help_tooltip'],
-            placeholder="The text for the help button's tooltip",
-            title="The tooltip text for the optional help buttion in the application.")
-        button#g-hui-help-default-tooltip.form-control.input-sm(
-            type="button", title="Default text") default
-      else
-        input#g-hui-help-tooltip.form-control.input-sm(
-            type="text", value=settings['histomicsui.help_tooltip'],
-            placeholder="The text for the help button's tooltip", disabled,
-            title="The tooltip text for the optional help buttion in the application.")
-        button#g-hui-help-default-tooltip.form-control.input-sm(
-            type="button", title="Default text", disabled) default
+      input#g-hui-help-tooltip.form-control.input-sm(
+          type="text", value=settings['histomicsui.help_tooltip'],
+          placeholder="The text for the help button's tooltip",
+          title="The tooltip text for the optional help buttion in the application.")
+      button#g-hui-help-default-tooltip.form-control.input-sm(
+          type="button", title="Default tooltip") default
   .form-group
     label
       | Default styles for drawing annotations

--- a/histomicsui/web_client/templates/body/configView.pug
+++ b/histomicsui/web_client/templates/body/configView.pug
@@ -35,7 +35,7 @@ form#g-hui-form(role="form")
     #g-hui-help-url-container
       input#g-hui-help-url.form-control.input-sm(
           type="text", value=settings['histomicsui.help_url'],
-          placeholder="(Optional) A URL to direct users to to provide help"
+          placeholder="(Optional) A URL to direct users to to provide help",
           title="The link that the optional help button in the application should lead to.  If no URL is specified, the help button won't be displayed.")
       button#g-hui-help-default-url.form-control.input-sm(
           type="button", title="Default URL") default
@@ -45,14 +45,14 @@ form#g-hui-form(role="form")
       - if (settings['histomicsui.help_url'].trim() == '')
         input#g-hui-help-tooltip.form-control.input-sm(
             type="text", value=settings['histomicsui.help_tooltip'],
-            placeholder="The text for the help button's tooltip", disabled
+            placeholder="The text for the help button's tooltip", disabled,
             title="The tooltip text for the optional help buttion in the application.")
         button#g-hui-help-default-tooltip.form-control.input-sm(
             type="button", title="Default text", disabled) default
       - else
         input#g-hui-help-tooltip.form-control.input-sm(
             type="text", value=settings['histomicsui.help_tooltip'],
-            placeholder="The text for the help button's tooltip"
+            placeholder="The text for the help button's tooltip",
             title="The tooltip text for the optional help buttion in the application.")
         button#g-hui-help-default-tooltip.form-control.input-sm(
             type="button", title="Default text") default

--- a/histomicsui/web_client/templates/body/configView.pug
+++ b/histomicsui/web_client/templates/body/configView.pug
@@ -31,6 +31,18 @@ form#g-hui-form(role="form")
       button#g-hui-banner-default-color.form-control.input-sm(
           type="button", title="Default color") default
   .form-group
+    label(for="g-hui-help-url") Help URL
+    #g-hui-help-url-container
+      input#g-hui-help-url.form-control.input-sm(
+          type="text", value=settings['histomicsui.help_url'] || defaults['histomicsui.help_url'],
+          title="The link for the optional help button in the application.")
+  .form-group
+    label(for="g-hui-help-tooltip") Help Tooltip
+    #g-hui-help-tooltip-container
+      input#g-hui-help-tooltip.form-control.input-sm(
+          type="text", value=settings['histomicsui.help_tooltip'] || defaults['histomicsui.help_tooltip'],
+          title="The tooltip text for the optional help buttion in the application.")
+  .form-group
     label
       | Default styles for drawing annotations
     input#g-hui-default-draw-styles.input-sm.form-control(

--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -19,5 +19,5 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         li.h-current-user-wrapper.dropdown
         - if (helpURL.trim() !== '')
           li
-            a.h-help-button(role='button', title=helpTooltip, href=`${helpURL}`, target='_blank')
+            a.h-help-button(role='button', title=helpTooltip, href='${helpURL}', target='_blank')
               span.icon-help

--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -17,6 +17,7 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         li.h-image-menu-wrapper.dropdown
         li.h-analyses-wrapper.dropdown
         li.h-current-user-wrapper.dropdown
-        li
-          a.h-help-button(role='button', title=helpTooltip, href=`${helpURL}`, target='_blank')
-            span.icon-help
+        - if (helpURL.trim() !== '')
+          li
+            a.h-help-button(role='button', title=helpTooltip, href=`${helpURL}`, target='_blank')
+              span.icon-help

--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -18,6 +18,6 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         li.h-analyses-wrapper.dropdown
         li.h-current-user-wrapper.dropdown
         if helpURL
-          li
+          li.h-help-button-wrapper
             a.h-help-button(role='button', title=helpTooltip, href=helpURL, target='_blank')
               span.icon-help

--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -17,3 +17,6 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         li.h-image-menu-wrapper.dropdown
         li.h-analyses-wrapper.dropdown
         li.h-current-user-wrapper.dropdown
+        li
+          a.h-help-button(role='button', title=helpTooltip, href=`${helpURL}`, target='_blank')
+            span.icon-help

--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -17,7 +17,7 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         li.h-image-menu-wrapper.dropdown
         li.h-analyses-wrapper.dropdown
         li.h-current-user-wrapper.dropdown
-        - if (helpURL.trim() !== '')
+        if helpURL
           li
             a.h-help-button(role='button', title=helpTooltip, href=helpURL, target='_blank')
               span.icon-help

--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -19,5 +19,5 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         li.h-current-user-wrapper.dropdown
         - if (helpURL.trim() !== '')
           li
-            a.h-help-button(role='button', title=helpTooltip, href='${helpURL}', target='_blank')
+            a.h-help-button(role='button', title=helpTooltip, href=helpURL, target='_blank')
               span.icon-help

--- a/histomicsui/web_client/templates/layout/header.pug
+++ b/histomicsui/web_client/templates/layout/header.pug
@@ -19,5 +19,5 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         li.h-current-user-wrapper.dropdown
         if helpURL
           li.h-help-button-wrapper
-            a.h-help-button(role='button', title=helpTooltip, href=helpURL, target='_blank')
-              span.icon-help
+            a.h-help-button(role='button', title=helpTooltip, href=helpURL, target='_blank') #{helpText}
+              span.icon-help-circled

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -58,7 +58,7 @@ var ConfigView = View.extend({
             router.navigate('plugins', { trigger: true });
         },
         'change #g-hui-help-url': function (event) {
-            if (this.$('#g-hui-help-url').val().trim() == '') {
+            if (this.$('#g-hui-help-url').val().trim() === '') {
                 this.$('#g-hui-help-tooltip-container').children().attr('disabled', 'disabled');
             } else {
                 this.$('#g-hui-help-tooltip-container').children().removeAttr('disabled');

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -33,6 +33,10 @@ var ConfigView = View.extend({
                     case 'histomicsui.delete_annotations_after_ingest':
                         result.value = this.$('.g-hui-delete-annotations-after-ingest').prop('checked');
                         break;
+                    case 'histomicsui.help_url':
+                    case 'histomicsui.help_tooltip':
+                        result.value = result.value === null || !result.value.trim() ? '' : result.value;
+                        break;
                 }
                 return result;
             });

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -50,6 +50,7 @@ var ConfigView = View.extend({
         },
         'click #g-hui-help-default-url': function () {
             this.$('#g-hui-help-url').val(this.defaults['histomicsui.help_url']);
+            this.$('#g-hui-help-url').trigger('change');
         },
         'click #g-hui-help-default-tooltip': function () {
             this.$('#g-hui-help-tooltip').val(this.defaults['histomicsui.help_tooltip']);

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -63,7 +63,9 @@ var ConfigView = View.extend({
             'histomicsui.default_draw_styles',
             'histomicsui.panel_layout',
             'histomicsui.quarantine_folder',
-            'histomicsui.delete_annotations_after_ingest'
+            'histomicsui.delete_annotations_after_ingest',
+            'histomicsui.help_url',
+            'histomicsui.help_tooltip'
         ];
         $.when(
             restRequest({

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -44,8 +44,21 @@ var ConfigView = View.extend({
         'click #g-hui-banner-default-color': function () {
             this.$('#g-hui-banner-color').val(this.defaults['histomicsui.banner_color']);
         },
+        'click #g-hui-help-default-url': function () {
+            this.$('#g-hui-help-url').val(this.defaults['histomicsui.help_url']);
+        },
+        'click #g-hui-help-default-tooltip': function () {
+            this.$('#g-hui-help-tooltip').val(this.defaults['histomicsui.help_tooltip']);
+        },
         'click #g-hui-cancel': function (event) {
             router.navigate('plugins', { trigger: true });
+        },
+        'change #g-hui-help-url': function (event) {
+            if (this.$('#g-hui-help-url').val().trim() == '') {
+                this.$('#g-hui-help-tooltip-container').children().attr('disabled', 'disabled');
+            } else {
+                this.$('#g-hui-help-tooltip-container').children().removeAttr('disabled');
+            }
         },
         'click .g-open-browser': '_openBrowser'
     },

--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -35,6 +35,7 @@ var ConfigView = View.extend({
                         break;
                     case 'histomicsui.help_url':
                     case 'histomicsui.help_tooltip':
+                    case 'histomicsui.help_text':
                         result.value = result.value === null || !result.value.trim() ? '' : result.value;
                         break;
                 }
@@ -52,6 +53,9 @@ var ConfigView = View.extend({
             this.$('#g-hui-help-url').val(this.defaults['histomicsui.help_url']);
             this.$('#g-hui-help-url').trigger('change');
         },
+        'click #g-hui-help-default-text': function () {
+            this.$('#g-hui-help-text').val(this.defaults['histomicsui.help_text']);
+        },
         'click #g-hui-help-default-tooltip': function () {
             this.$('#g-hui-help-tooltip').val(this.defaults['histomicsui.help_tooltip']);
         },
@@ -60,8 +64,10 @@ var ConfigView = View.extend({
         },
         'change #g-hui-help-url': function (event) {
             if (this.$('#g-hui-help-url').val().trim() === '') {
+                this.$('#g-hui-help-text-container').children().attr('disabled', 'disabled');
                 this.$('#g-hui-help-tooltip-container').children().attr('disabled', 'disabled');
             } else {
+                this.$('#g-hui-help-text-container').children().removeAttr('disabled');
                 this.$('#g-hui-help-tooltip-container').children().removeAttr('disabled');
             }
         },
@@ -83,7 +89,8 @@ var ConfigView = View.extend({
             'histomicsui.quarantine_folder',
             'histomicsui.delete_annotations_after_ingest',
             'histomicsui.help_url',
-            'histomicsui.help_tooltip'
+            'histomicsui.help_tooltip',
+            'histomicsui.help_text'
         ];
         $.when(
             restRequest({
@@ -145,6 +152,7 @@ var ConfigView = View.extend({
             settings: this.settings,
             defaults: this.defaults
         }));
+        this.$('#g-hui-help-url').trigger('change');
         this.breadcrumb.setElement(this.$('.g-config-breadcrumb-container')).render();
         return this;
     },

--- a/histomicsui/web_client/views/layout/HeaderView.js
+++ b/histomicsui/web_client/views/layout/HeaderView.js
@@ -24,7 +24,7 @@ var HeaderView = View.extend({
             brandName: this.settings.brandName,
             brandColor: this.settings.brandColor,
             bannerColor: this.settings.bannerColor,
-            helpURL: this.settings.helpURL,
+            helpURL: this.settings.helpURL && this.settings.helpURL.trim() === '' ? false : this.settings.helpURL,
             helpTooltip: this.settings.helpTooltip
         }));
 

--- a/histomicsui/web_client/views/layout/HeaderView.js
+++ b/histomicsui/web_client/views/layout/HeaderView.js
@@ -25,7 +25,8 @@ var HeaderView = View.extend({
             brandColor: this.settings.brandColor,
             bannerColor: this.settings.bannerColor,
             helpURL: this.settings.helpURL && this.settings.helpURL.trim() === '' ? false : this.settings.helpURL,
-            helpTooltip: this.settings.helpTooltip
+            helpTooltip: this.settings.helpTooltip,
+            helpText: this.settings.helpText
         }));
 
         this.$('a[title]').tooltip({

--- a/histomicsui/web_client/views/layout/HeaderView.js
+++ b/histomicsui/web_client/views/layout/HeaderView.js
@@ -23,7 +23,9 @@ var HeaderView = View.extend({
         this.$el.html(headerTemplate({
             brandName: this.settings.brandName,
             brandColor: this.settings.brandColor,
-            bannerColor: this.settings.bannerColor
+            bannerColor: this.settings.bannerColor,
+            helpURL: this.settings.helpURL,
+            helpTooltip: this.settings.helpTooltip
         }));
 
         this.$('a[title]').tooltip({

--- a/histomicsui/webroot.mako
+++ b/histomicsui/webroot.mako
@@ -26,7 +26,8 @@
         brandColor: '${huiBrandColor | js}',
         bannerColor: '${huiBannerColor | js}',
         helpURL: '${huiHelpURL | js}',
-        helpTooltip: '${huiHelpTooltip | js}'
+        helpTooltip: '${huiHelpTooltip | js}',
+        helpText: '${huiHelpText | js}'
       });
       app.bindRoutes();
       girder.events.trigger('g:appload.after');

--- a/histomicsui/webroot.mako
+++ b/histomicsui/webroot.mako
@@ -25,6 +25,8 @@
         brandName: '${huiBrandName | js}',
         brandColor: '${huiBrandColor | js}',
         bannerColor: '${huiBannerColor | js}',
+        helpURL: '${huiHelpURL | js}',
+        helpTooltip: '${huiHelpTooltip | js}'
       });
       app.bindRoutes();
       girder.events.trigger('g:appload.after');


### PR DESCRIPTION
Adds an optional help button to the header of HistomicsUI (at the far right) as well as the ability to change the URL it leads to and its tooltip via the HistomicsUI plugin settings.

Closes #193 