### PR TITLE
Add internal pixelmap count to annotation/group count

### DIFF
--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -772,8 +772,8 @@ var DrawWidget = Panel.extend({
 
     countPixelmap(pixelmap, operation) {
         let toChange = {};
-        for (let ix = 0; ix < pixelmap.attributes.values.length / 2; ix++) {
-            let groupName = (pixelmap.attributes.categories[pixelmap.attributes.values[ix]]).label || 'default';
+        for (let ix = 0; ix < (pixelmap.get('boundaries') ? pixelmap.get('values').length / 2 : pixelmap.get('values').length); ix++) {
+            let groupName = (pixelmap.get('categories')[pixelmap.get('values')[ix]]).label || 'default';
             if (toChange[groupName]) {
                 toChange[groupName]++;
             } else {

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -125,6 +125,10 @@ var DrawWidget = Panel.extend({
         } else {
             this.$('.h-group-count').hide();
         }
+        if (this.$('.h-group-count-option.pixelmap').length > 0) {
+            this.$('.h-group-count-option.pixelmap').remove();
+            this.countPixelmap();
+        }
         if (this._drawingType) {
             this.$('button.h-draw[data-type="' + this._drawingType + '"]').addClass('active');
             this.drawElement(undefined, this._drawingType);
@@ -291,6 +295,19 @@ var DrawWidget = Panel.extend({
         }
         if (['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(this.collection.get(id).attributes.type)) {
             this.updateCount(this.collection.get(id).attributes.group || 'default', -1);
+        } else if (this.collection.get(id).attributes.type === 'pixelmap') {
+            let toSubtract = {};
+            for (let ix=0; ix < this.collection.get(id).attributes.values.length / 2; ix++) {
+                let groupName = (this.collection.get(id).attributes.categories[this.collection.get(id).attributes.values[ix]]).label || 'default';
+                if (toSubtract[groupName]) {
+                    toSubtract[groupName]--;
+                } else {
+                    toSubtract[groupName] = -1;
+                }
+            }
+            for (let group in toSubtract) {
+                this.updateCount(group, toSubtract[group]);
+            }
         }
         this.$(`.h-element[data-id="${id}"]`).remove();
         this._skipRenderHTML = true;
@@ -722,6 +739,25 @@ var DrawWidget = Panel.extend({
             $('.h-group-count').hide();
         } else {
             $('.h-group-count').show();
+        }
+    },
+
+    countPixelmap() {
+        let toAdd = {};
+        for (let element of this.collection.models) {
+            if (element.attributes.type == 'pixelmap') {
+                for (let ix=0; ix < element.attributes.values.length / 2; ix++) {
+                    let groupName = (element.attributes.categories[element.attributes.values[ix]]).label || 'default';
+                    if (toAdd[groupName]) {
+                        toAdd[groupName]++;
+                    } else {
+                        toAdd[groupName] = 1;
+                    }
+                }
+            }
+        }
+        for (let group in toAdd) {
+            this.updateCount(group, toAdd[group]);
         }
     },
 

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -208,7 +208,7 @@ var DrawWidget = Panel.extend({
                     group = obj.data.group;
                 label = label || (elemType === 'polyline' ? (obj.element.get('closed') ? 'polygon' : 'line') : elemType);
                 this.$(`.h-element[data-id="${id}"] .h-element-label`).text(label).attr('title', label);
-                if (origGroup !== group) {
+                if (origGroup !== group && ['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(elemType)) {
                     this.updateCount(origGroup || 'default', -1);
                     this.updateCount(group || 'default', 1);
                 }

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -127,7 +127,11 @@ var DrawWidget = Panel.extend({
         }
         if (this.$('.h-group-count-option.pixelmap').length > 0) {
             this.$('.h-group-count-option.pixelmap').remove();
-            this.countPixelmap();
+            for (let element of this.collection.models) {
+                if (element.attributes.type === 'pixelmap') {
+                    this.countPixelmap(element, 1);
+                }
+            }
         }
         if (this._drawingType) {
             this.$('button.h-draw[data-type="' + this._drawingType + '"]').addClass('active');
@@ -296,18 +300,7 @@ var DrawWidget = Panel.extend({
         if (['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(this.collection.get(id).attributes.type)) {
             this.updateCount(this.collection.get(id).attributes.group || 'default', -1);
         } else if (this.collection.get(id).attributes.type === 'pixelmap') {
-            let toSubtract = {};
-            for (let ix = 0; ix < this.collection.get(id).attributes.values.length / 2; ix++) {
-                let groupName = (this.collection.get(id).attributes.categories[this.collection.get(id).attributes.values[ix]]).label || 'default';
-                if (toSubtract[groupName]) {
-                    toSubtract[groupName]--;
-                } else {
-                    toSubtract[groupName] = -1;
-                }
-            }
-            for (let group in toSubtract) {
-                this.updateCount(group, toSubtract[group]);
-            }
+            this.countPixelmap(this.collection.get(id), -1);
         }
         this.$(`.h-element[data-id="${id}"]`).remove();
         this._skipRenderHTML = true;
@@ -742,22 +735,18 @@ var DrawWidget = Panel.extend({
         }
     },
 
-    countPixelmap() {
-        let toAdd = {};
-        for (let element of this.collection.models) {
-            if (element.attributes.type === 'pixelmap') {
-                for (let ix = 0; ix < element.attributes.values.length / 2; ix++) {
-                    let groupName = (element.attributes.categories[element.attributes.values[ix]]).label || 'default';
-                    if (toAdd[groupName]) {
-                        toAdd[groupName]++;
-                    } else {
-                        toAdd[groupName] = 1;
-                    }
-                }
+    countPixelmap(pixelmap, operation) {
+        let toChange = {};
+        for (let ix = 0; ix < pixelmap.attributes.values.length / 2; ix++) {
+            let groupName = (pixelmap.attributes.categories[pixelmap.attributes.values[ix]]).label || 'default';
+            if (toChange[groupName]) {
+                toChange[groupName]++;
+            } else {
+                toChange[groupName] = 1;
             }
         }
-        for (let group in toAdd) {
-            this.updateCount(group, toAdd[group]);
+        for (let group in toChange) {
+            this.updateCount(group, operation * toChange[group]);
         }
     },
 

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -724,17 +724,44 @@ var DrawWidget = Panel.extend({
         }
     },
 
-    updateCount(group, change) {
-        const groupElem = $('.h-group-count-options > [data-group="' + group + '"]');
+    updateCount(groupName, change) {
+        const groupElem = $('.h-group-count-options > [data-group="' + groupName + '"]');
         if (groupElem.length > 0) {
-            groupElem.attr('data-count', parseInt(groupElem.attr('data-count')) + change);
-            if (parseInt($(groupElem).attr('data-count')) > 0) {
-                groupElem.html($(groupElem).attr('data-count') + ' ' + $(groupElem).attr('data-group')).show();
+            let newCount =  parseInt(groupElem.attr('data-count')) + change;
+            groupElem.attr('data-count', newCount);
+            if (newCount > 0) {
+                for (let group of $('.h-group-count-option').toArray()) {
+                    let count = parseInt($(group).attr('data-count'));
+                    if (newCount > count) {
+                        $(group).before(groupElem);
+                        break;
+                    } else if (group !== groupElem[0] && newCount === count) {
+                        if ($(group).attr('data-group') < groupName) {
+                            $(group).after(groupElem);
+                        } else {
+                            $(group).before(groupElem);
+                        }
+                        break;
+                    } else if (group === $('.h-group-count-options:last-child')[0]) {
+                        $(group).after(groupElem);
+                    }
+                }
+                groupElem.html(newCount + ' ' + groupName).show();
             } else {
                 groupElem.remove();
             }
         } else if (change !== 0) {
-            $('.h-group-count-options').append('<div class = h-group-count-option data-group="' + group + '" data-count=' + change + '>' + change + ' ' + group + '</div>');
+            for (let group of $('.h-group-count-option').toArray().reverse()) {
+                if ($(group).attr('data-count') > change || ($(group).attr('data-count') === change && $(group).attr('data-group') < groupName)) {
+                    $(group).after('<div class = h-group-count-option data-group="' + groupName + '" data-count=' + change + '>' + change + ' ' + groupName + '</div>');
+                    break;
+                } else if (group === $('.h-group-count-options:first-child')[0]) {
+                    $(group).before('<div class = h-group-count-option data-group="' + groupName + '" data-count=' + change + '>' + change + ' ' + groupName + '</div>');
+                }
+            }
+            if ($('.h-group-count-options > [data-group="' + groupName + '"]').length === 0) {
+                $('.h-group-count-options').append('<div class = h-group-count-option data-group="' + groupName + '" data-count=' + change + '>' + change + ' ' + groupName + '</div>');
+            }
         }
         if ($('.h-group-count-option').length === 0) {
             $('.h-group-count').hide();

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -297,7 +297,7 @@ var DrawWidget = Panel.extend({
             this.updateCount(this.collection.get(id).attributes.group || 'default', -1);
         } else if (this.collection.get(id).attributes.type === 'pixelmap') {
             let toSubtract = {};
-            for (let ix=0; ix < this.collection.get(id).attributes.values.length / 2; ix++) {
+            for (let ix = 0; ix < this.collection.get(id).attributes.values.length / 2; ix++) {
                 let groupName = (this.collection.get(id).attributes.categories[this.collection.get(id).attributes.values[ix]]).label || 'default';
                 if (toSubtract[groupName]) {
                     toSubtract[groupName]--;
@@ -745,8 +745,8 @@ var DrawWidget = Panel.extend({
     countPixelmap() {
         let toAdd = {};
         for (let element of this.collection.models) {
-            if (element.attributes.type == 'pixelmap') {
-                for (let ix=0; ix < element.attributes.values.length / 2; ix++) {
+            if (element.attributes.type === 'pixelmap') {
+                for (let ix = 0; ix < element.attributes.values.length / 2; ix++) {
                     let groupName = (element.attributes.categories[element.attributes.values[ix]]).label || 'default';
                     if (toAdd[groupName]) {
                         toAdd[groupName]++;

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -325,6 +325,14 @@ var DrawWidget = Panel.extend({
                 updateCount: this.updateCount
             })
         );
+        if (this.$('.h-group-count-option.pixelmap').length > 0) {
+            this.$('.h-group-count-option.pixelmap').remove();
+            for (let element of this.collection.models) {
+                if (element.attributes.type === 'pixelmap') {
+                    this.countPixelmap(element, 1);
+                }
+            }
+        }
     },
 
     /**

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -27,10 +27,10 @@ if firstRender
   -
     var order = (Object.entries(counts)).sort((a, b) => {
       if (a[1] === b[1]) {
-        if (a[0] < b[0]) {
-          return -1;
+        if (a[0] > b[0]) {
+          return 1;
         }
-        return 1;
+        return -1;
       }
       return b[1] - a[1];
     })

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -1,4 +1,5 @@
 - var counts = {};
+- var pixelmap = false;
 if elements.length
   each element in elements
     -
@@ -11,6 +12,8 @@ if elements.length
         } else {
           counts[groupName] = 1;
         }
+      } else if (element.type === 'pixelmap') {
+        pixelmap = true;
       }
       var label = (element.label || {}).value || (element.type === 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type);
     .h-element(data-id=element.id, class=classes)
@@ -19,8 +22,10 @@ if elements.length
       span.icon-zoom-in.h-view-element(title='View annotation')
       span.icon-cancel.h-delete-element(title='Remove')
 if firstRender
+  if pixelmap
+    .h-group-count-option.pixelmap.hidden
   - for (let group in counts)
     .h-group-count-option(data-group=group, data-count=counts[group]) #{counts[group]} #{group}
-else
+else if !pixelmap
   - for (let group in counts)
     - updateCount(group, counts[group]);

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -24,8 +24,18 @@ if elements.length
 if pixelmap
   .h-group-count-option.pixelmap.hidden
 if firstRender
-  - for (let group in counts)
-    .h-group-count-option(data-group=group, data-count=counts[group]) #{counts[group]} #{group}
+  -
+    var order = (Object.entries(counts)).sort((a, b) => {
+      if (a[1] === b[1]) {
+        if (a[0] < b[0]) {
+          return -1;
+        }
+        return 1;
+      }
+      return b[1] - a[1];
+    })
+  - for (let group of order)
+    .h-group-count-option(data-group=group[0], data-count=group[1]) #{group[1]} #{group[0]}
 else
   - for (let group in counts)
     - updateCount(group, counts[group]);

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -21,11 +21,11 @@ if elements.length
       span.h-element-label(title=label) #{label}
       span.icon-zoom-in.h-view-element(title='View annotation')
       span.icon-cancel.h-delete-element(title='Remove')
+if pixelmap
+  .h-group-count-option.pixelmap.hidden
 if firstRender
-  if pixelmap
-    .h-group-count-option.pixelmap.hidden
   - for (let group in counts)
     .h-group-count-option(data-group=group, data-count=counts[group]) #{counts[group]} #{group}
-else if !pixelmap
+else
   - for (let group in counts)
     - updateCount(group, counts[group]);

--- a/histomicsui/web_client/views/popover/AnnotationContextMenu.js
+++ b/histomicsui/web_client/views/popover/AnnotationContextMenu.js
@@ -37,9 +37,12 @@ const AnnotationContextMenu = View.extend({
         evt.preventDefault();
         evt.stopPropagation();
         this.collection.each((element) => {
-            if (this.parentView.drawWidget && this.parentView.activeAnnotation.id === element.originalAnnotation.id &&
-                ['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(element.attributes.type)) {
-                this.parentView.drawWidget.updateCount(element.attributes.group || 'default', -1);
+            if (this.parentView.drawWidget && this.parentView.activeAnnotation.id === element.originalAnnotation.id) {
+                if (['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(element.attributes.type)) {
+                    this.parentView.drawWidget.updateCount(element.attributes.group || 'default', -1);
+                } else if (element.attributes.type === 'pixelmap') {
+                    this.parentView.drawWidget.countPixelmap(element, -1);
+                }
             }
         });
         this.collection.trigger('h:remove');


### PR DESCRIPTION
Counts the number of cells within a pixelmap that belong to each annotation group and adds the totals to the existing count for individual elements.  Also updates the count when changes are made to the groups of the cells within the pixelmap or when the pixelmap is deleted.

Closes #200 