### PR TITLE
Add webapck alias for vue

### DIFF
--- a/histomicsui/web_client/vue/components/EditHeatmapOrGridDataContainer.vue
+++ b/histomicsui/web_client/vue/components/EditHeatmapOrGridDataContainer.vue
@@ -1,6 +1,6 @@
 <script>
 import _ from 'underscore';
-import Vue from 'vue/dist/vue.js';
+import Vue from 'vue';
 
 import EditHeatmapOrGridData from './EditHeatmapOrGridData.vue';
 export default Vue.extend({

--- a/histomicsui/web_client/webpack.helper.js
+++ b/histomicsui/web_client/webpack.helper.js
@@ -22,6 +22,11 @@ module.exports = function (config) {
             require.resolve('vue-loader')
         ]
     });
+    config.resolve = {
+        alias: {
+            vue: process.env.NODE_ENV === 'production' ? 'vue/dist/vue.min.js' : 'vue/dist/vue.js'
+        }
+    };
     config.plugins.push(new VueLoaderPlugin());
     return config;
 };


### PR DESCRIPTION
Resolves #190 

This PR adds an alias to the webpack helper for HistomicsUI. The alias evaluates to `vue.min.js` if built in production, otherwise it evaluates to `vue.js` to allow running Vue in development mode when developing future Vue components for Histomics UI.