### PR TITLE
Add an endpoint to get default settings.

### DIFF
--- a/histomicsui/web_client/views/body/ConfigView.js
+++ b/histomicsui/web_client/views/body/ConfigView.js
@@ -68,7 +68,7 @@ var ConfigView = View.extend({
         $.when(
             restRequest({
                 method: 'GET',
-                url: 'system/setting',
+                url: 'system/setting/default',
                 data: {
                     list: JSON.stringify(this.settingsKeys),
                     default: 'none'
@@ -78,7 +78,7 @@ var ConfigView = View.extend({
             }),
             restRequest({
                 method: 'GET',
-                url: 'system/setting',
+                url: 'system/setting/default',
                 data: {
                     list: JSON.stringify(this.settingsKeys),
                     default: 'default'


### PR DESCRIPTION
Quite a long time ago, Girder removed the ability to ask for the default settings, which made the default buttons in the plugin settings page not work as intended.  This fixes that.