### PR TITLE
Click buffer of 10px - missing annotations

### DIFF
--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -221,6 +221,10 @@ var ImageView = View.extend({
                 // store a reference to the underlying viewer
                 this.viewer = this.viewerWidget.viewer;
                 this.viewer.interactor().removeAction(geo.geo_action.zoomselect);
+                
+                let currentOptions = this.viewer.interactor().options();
+                currentOptions.click.cancelOnMove = 10;  // a click can move up to 10 pixels before it is considered a move
+                this.viewer.interactor().options(currentOptions)
 
                 this.imageWidth = this.viewer.maxBounds().right;
                 this.imageHeight = this.viewer.maxBounds().bottom;


### PR DESCRIPTION
This issue was already discussed in #125 and it's almost urgent to have it, according to our labeling experience. Especially, when point annotations are required. This safety buffer is even more important if tablets and stylus pens are used. It greatly reduces the number of missed annotations to almost 0. It's a quick fix and maybe a dirty fix, but it does the job according to our field tests.