### PR TITLE
Add more descriptive element labels

### DIFF
--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -218,7 +218,7 @@ var DrawWidget = Panel.extend({
                 if (label) {
                     newLabel = label;
                 } else if (['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(elemType)) {
-                    newLabel = `${group || 'default'} ${elemType} ${parseInt(oldLabel[oldLabel.length -1] || '')}`;
+                    newLabel = `${group || 'default'} ${elemType} ${parseInt(oldLabel[oldLabel.length - 1] || '')}`;
                 } else {
                     newLabel = oldLabel;
                 }

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -49,6 +49,7 @@ var DrawWidget = Panel.extend({
         this.image = settings.image;
         this.annotation = settings.annotation;
         this.collection = this.annotation.elements();
+        this.newElementDisplayIdStart = this.collection.length;
         this.viewer = settings.viewer;
         this.setViewer(settings.viewer);
         this.setAnnotationSelector(settings.annotationSelector);
@@ -114,7 +115,8 @@ var DrawWidget = Panel.extend({
                 opts: this._editOptions,
                 drawingType: this._drawingType,
                 collapsed: this.$('.s-panel-content.collapse').length && !this.$('.s-panel-content').hasClass('in'),
-                firstRender: true
+                firstRender: true,
+                displayIdStart: 0
             }));
             this.$('.h-dropdown-content').collapse({toggle: false});
         }
@@ -322,9 +324,11 @@ var DrawWidget = Panel.extend({
                 style: this._style.id,
                 highlighted: this._highlighted,
                 firstRender: false,
-                updateCount: this.updateCount
+                updateCount: this.updateCount,
+                displayIdStart: this.newElementDisplayIdStart
             })
         );
+        this.newElementDisplayIdStart += elements.length;
         if (this.$('.h-group-count-option.pixelmap').length > 0) {
             this.$('.h-group-count-option.pixelmap').remove();
             for (let element of this.collection.models) {

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -212,8 +212,17 @@ var DrawWidget = Panel.extend({
                     label = (obj.data.label || {}).value,
                     elemType = obj.element.get('type'),
                     group = obj.data.group;
-                label = label || (elemType === 'polyline' ? (obj.element.get('closed') ? 'polygon' : 'line') : elemType);
-                this.$(`.h-element[data-id="${id}"] .h-element-label`).text(label).attr('title', label);
+                let newLabel = '';
+                const labelElement = this.$(`.h-element[data-id="${id}"] .h-element-label`);
+                const oldLabel = labelElement.text().split(' ');
+                if (label) {
+                    newLabel = label;
+                } else if (['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(elemType)) {
+                    newLabel = `${group || 'default'} ${elemType} ${parseInt(oldLabel[oldLabel.length -1] || '')}`;
+                } else {
+                    newLabel = oldLabel;
+                }
+                this.$(`.h-element[data-id="${id}"] .h-element-label`).text(newLabel).attr('title', label);
                 if (origGroup !== group && ['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(elemType)) {
                     this.updateCount(origGroup || 'default', -1);
                     this.updateCount(group || 'default', 1);

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -1,6 +1,7 @@
 - var counts = {};
 - var displayIdOffset = 0;
 - var pixelmap = false;
+- var typeCounts = {};
 if elements.length
   each element in elements
     -
@@ -9,15 +10,23 @@ if elements.length
       var groupName = element['group'] ? element['group'] : 'default';
       var type = element.type == 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type;
       var displayId = ++displayIdOffset + displayIdStart;
-      var label = ((element.label || {}).value || type) + ' ' + displayId;
+      var label = ((element.label || {}).value || type);
       if (['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(element.type)) {
         if (counts[groupName]) {
           counts[groupName]++;
         } else {
           counts[groupName] = 1;
         }
-        label = groupName + ' ' + label;
-      } else if (element.type === 'pixelmap') {
+        label = groupName + ' ' + label + ' ' + displayId;
+      } else {
+        if (typeCounts[type] > 0) {
+          label = label + ' ' + displayId;
+          typeCounts[type]++;
+        } else {
+          typeCounts[type] = 1;
+        }
+      }
+      if (element.type === 'pixelmap') {
         pixelmap = true;
       }
     .h-element(data-id=element.id, class=classes)

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -1,4 +1,5 @@
 - var counts = {};
+- var shapeCounts = {};
 - var pixelmap = false;
 if elements.length
   each element in elements
@@ -15,7 +16,8 @@ if elements.length
       } else if (element.type === 'pixelmap') {
         pixelmap = true;
       }
-      var label = (element.label || {}).value || (element.type === 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type);
+      var type = element.type == 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type;
+      var label = (element.label || {}).value || type;
     .h-element(data-id=element.id, class=classes)
       span.icon-cog.h-edit-element(title='Change style')
       span.h-element-label(title=label) #{label}

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -7,18 +7,19 @@ if elements.length
       var classes = highlighted[element.id] ? ['h-highlight-element'] : [];
       element = element.toJSON();
       var groupName = element['group'] ? element['group'] : 'default';
+      var type = element.type == 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type;
+      var displayId = ++displayIdOffset + displayIdStart;
+      var label = ((element.label || {}).value || type) + ' ' + displayId;
       if (['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(element.type)) {
         if (counts[groupName]) {
           counts[groupName]++;
         } else {
           counts[groupName] = 1;
         }
+        label = groupName + ' ' + label;
       } else if (element.type === 'pixelmap') {
         pixelmap = true;
       }
-      var type = element.type == 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type;
-      var displayId = ++displayIdOffset + displayIdStart;
-      var label = ((element.label || {}).value || type) + ' ' + displayId;
     .h-element(data-id=element.id, class=classes)
       span.icon-cog.h-edit-element(title='Change style')
       span.h-element-label(title=label) #{label}

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -1,5 +1,5 @@
 - var counts = {};
-- var shapeCounts = {};
+- var displayIdOffset = 0;
 - var pixelmap = false;
 if elements.length
   each element in elements
@@ -17,7 +17,8 @@ if elements.length
         pixelmap = true;
       }
       var type = element.type == 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type;
-      var label = (element.label || {}).value || type;
+      var displayId = ++displayIdOffset + displayIdStart;
+      var label = ((element.label || {}).value || type) + ' ' + displayId;
     .h-element(data-id=element.id, class=classes)
       span.icon-cog.h-edit-element(title='Change style')
       span.h-element-label(title=label) #{label}

--- a/tests/web_client_specs/annotationSpec.js
+++ b/tests/web_client_specs/annotationSpec.js
@@ -221,7 +221,7 @@ girderTest.promise.done(function () {
                     return $('.h-elements-container .h-element').length === 1;
                 }, 'point to be created');
                 runs(function () {
-                    expect($('.h-elements-container .h-element .h-element-label').text()).toBe('point');
+                    expect($('.h-elements-container .h-element .h-element-label').text()).toBe('default point 1');
                     expect($('.h-draw[data-type="point"]').hasClass('active')).toBe(true);
                     // turn off point drawing.
                     $('.h-draw[data-type="point"]').click();
@@ -275,7 +275,7 @@ girderTest.promise.done(function () {
                     return $('.h-elements-container .h-element').length === 2;
                 }, 'point to be created');
                 runs(function () {
-                    expect($('.h-elements-container .h-element:last .h-element-label').text()).toBe('point');
+                    expect($('.h-elements-container .h-element:last .h-element-label').text()).toBe('default point 2');
                 });
                 checkAutoSave('drawn 1', 2, annotationInfo);
             });
@@ -311,7 +311,7 @@ girderTest.promise.done(function () {
                     return $('.h-elements-container .h-element').length === 2;
                 }, 'point to be created');
                 runs(function () {
-                    expect($('.h-elements-container .h-element:last .h-element-label').text()).toBe('point');
+                    expect($('.h-elements-container .h-element:last .h-element-label').text()).toBe('default point 3');
                 });
                 checkAutoSave('drawn 1', 2, annotationInfo);
             });


### PR DESCRIPTION
Resolves #195 

This PR creates more descriptive element labels for annotations listed in the draw widget. In addition to the element type, for point, rectangle, ellipse, circle and polyline elements, the group name of the element and a number is added to the element label. 

If an element is assigned a new group when edited, the label is updated to reflect the new group. 

The number corresponding to each element is just a counter that starts at 1 and counts up for each element in the annotation. It is not a long-term ID for the element, and more of a way to more easily differentiate between two elements in the list. New elements added to the annotation (e.g. by being drawn on) are assigned a number as well. When the page is refreshed, the numbers are recalculated. This design might not be optimal and is intended to be a starting point.