### PR TITLE
Allow flake8 to be an implied dependency.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,6 @@ extras =
 skipsdist = true
 skip_install = true
 deps =
-  flake8
   flake8-bugbear
   flake8-docstrings
   flake8-isort


### PR DESCRIPTION
This allows pip to resolve working versions correctly.