### PR TITLE
Use new annotation creation access flag

### DIFF
--- a/histomicsui/web_client/dialogs/saveAnnotation.js
+++ b/histomicsui/web_client/dialogs/saveAnnotation.js
@@ -73,7 +73,8 @@ var SaveAnnotation = View.extend({
             type: 'annotation',
             hideRecurseOption: true,
             parentView: this,
-            model: this.annotation
+            model: this.annotation,
+            noAccessFlag: true
         }).on('g:accessListSaved', () => {
             this.annotation.fetch();
         });

--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import $ from 'jquery';
 
+import { restRequest } from '@girder/core/rest';
 import { AccessType } from '@girder/core/constants';
 import eventStream from '@girder/core/utilities/EventStream';
 import { getCurrentUser } from '@girder/core/auth';
@@ -68,8 +69,11 @@ var AnnotationSelector = Panel.extend({
 
     render() {
         this._debounceRenderRequest = null;
-        if (this.parentItem && this.parentItem.id) {
-            this.parentItem.getAccessLevel((imageAccessLevel) => {
+        if (this.parentItem && this.parentItem.get('folderId')) {
+            restRequest({
+                type: 'GET',
+                url: 'annotation/folder/' + this.parentItem.get('folderId') + '/create'
+            }).done((createResp) => {
                 const annotationGroups = this._getAnnotationGroups();
                 if (!this.viewer) {
                     this.$el.empty();
@@ -81,7 +85,7 @@ var AnnotationSelector = Panel.extend({
                     activeAnnotation: this._activeAnnotation ? this._activeAnnotation.id : '',
                     showLabels: this._showLabels,
                     user: getCurrentUser() || {},
-                    accessLevel: imageAccessLevel,
+                    creationAccess: createResp,
                     writeAccessLevel: AccessType.WRITE,
                     writeAccess: this._writeAccess,
                     opacity: this._opacity,

--- a/histomicsui/web_client/templates/panels/annotationSelector.pug
+++ b/histomicsui/web_client/templates/panels/annotationSelector.pug
@@ -75,7 +75,7 @@ block content
     label(title='Highlight annotations when hovering with the mouse.')
       input#h-toggle-interactive(type='checkbox', checked=interactiveMode)
       | Interactive
-    if accessLevel >= writeAccessLevel
+    if creationAccess
       button.btn.btn-sm.btn-primary.h-create-annotation(title='Create a new annotation. Keyboard shortcut: space bar')
         | #[span.icon-plus-squared] New
     .clearfix


### PR DESCRIPTION
Uses the new annotation creation access flag and endpoint from PR [#937](https://github.com/girder/large_image/pull/937) in [girder/large_image](https://github.com/girder/large_image) to check whether the "New" annotation button should be shown in the image viewer.  Also prevents the access flag from appearing in the image viewer's individual annotation access control widget.

This PR should only be tested simultaneously with the [annotation-access-flag](https://github.com/girder/large_image/tree/annotation-access-flag) branch from girder/large_image and merged after it has been merged.

Closes #201