### PR TITLE
Fix issue with panel layout from new access flag use (PR #222)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     docker:
       - image: girder/tox-and-node
       - image: memcached
-      - image: mongo:4.0
+      - image: mongo:4.4
         command: bash -c "mkdir /dev/shm/mongo && mongod --nojournal --dbpath=/dev/shm/mongo --noauth --bind_ip_all"
       - image: rabbitmq
 commands:

--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -212,12 +212,12 @@ var AnnotationSelector = Panel.extend({
             url: 'annotation/folder/' + folderId + '/create'
         }).done((createResp) => {
             root.creationAccess = createResp;
-            if (createResp && root.$('.h-create-annotation').length == 0) {
+            if (createResp && root.$('.h-create-annotation').length === 0) {
                 root.$('.checkbox.h-annotation-toggle > .clearfix').before(
                     '<button class="btn btn-sm btn-primary h-create-annotation" title="Create a new annotation. Keyboard shortcut: space bar">' +
                         '<span class="icon-plus-squared"></span> New' +
                     '</button>'
-                )
+                );
             } else if (!createResp) {
                 root.$('.h-create-annotation').remove();
             }

--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -209,18 +209,13 @@ var AnnotationSelector = Panel.extend({
     _setCreationAccess(root, folderId) {
         restRequest({
             type: 'GET',
-            url: 'annotation/folder/' + folderId + '/create'
+            url: 'annotation/folder/' + folderId + '/create',
+            error: null
         }).done((createResp) => {
             root.creationAccess = createResp;
-            if (createResp && root.$('.h-create-annotation').length === 0) {
-                root.$('.checkbox.h-annotation-toggle > .clearfix').before(
-                    '<button class="btn btn-sm btn-primary h-create-annotation" title="Create a new annotation. Keyboard shortcut: space bar">' +
-                        '<span class="icon-plus-squared"></span> New' +
-                    '</button>'
-                );
-            } else if (!createResp) {
-                root.$('.h-create-annotation').remove();
-            }
+            root.$('.h-create-annotation').toggleClass('hidden', !createResp);
+        }).fail(() => {
+            root.$('.h-create-annotation').toggleClass('hidden', true);
         });
     },
 

--- a/histomicsui/web_client/templates/panels/annotationSelector.pug
+++ b/histomicsui/web_client/templates/panels/annotationSelector.pug
@@ -75,7 +75,6 @@ block content
     label(title='Highlight annotations when hovering with the mouse.')
       input#h-toggle-interactive(type='checkbox', checked=interactiveMode)
       | Interactive
-    if creationAccess
-      button.btn.btn-sm.btn-primary.h-create-annotation(title='Create a new annotation. Keyboard shortcut: space bar')
-        | #[span.icon-plus-squared] New
+    button.btn.btn-sm.btn-primary.h-create-annotation(title='Create a new annotation. Keyboard shortcut: space bar', class=annotationAccess ? '' : 'hidden')
+      | #[span.icon-plus-squared] New
     .clearfix


### PR DESCRIPTION
Follow up to #222 

The new large image release used in #222, uses a MongoDB operation added in Mongo version 4.4, however CI currently uses Mongo version 4.  This led #222 to periodically fail the `panelLayoutSpec.js` test upon merging, so this PR updates CI to use Mongo 4.4.

In addition, fixing this revealed that `panelLayoutSpec.js` was also failing because the rest request made to facilitate use of the new access flag endpoint was causing too much of a delay; this led `_orderPanels()` in `ImageView.js` to occasionally not display the annotation panel properly as directed by the plugin settings.  So this PR also moves the request such that the annotation panel can be rendered prior to the request being completed.