### PR TITLE
Generalize not closing modals when the mouse is dragged outside of it

### DIFF
--- a/histomicsui/web_client/views/View.js
+++ b/histomicsui/web_client/views/View.js
@@ -1,8 +1,14 @@
 import $ from 'jquery';
 import View from '@girder/core/views/View';
 
-export default View.extend({
-    initialize() {
+console.log(View);
+
+if (View.__super__ && View.__super__.initialize) {
+    const oldInitialize = View.__super__.initialize;
+
+    View.__super__.initialize = function () {
+        let result = oldInitialize.apply(this, arguments);
+
         // Bootstrap 3's default behavior is to close dialogs when a
         // `click` event occurs outside of it. By using the `click`
         // event, the following scenario could occur -
@@ -31,5 +37,8 @@ export default View.extend({
         $('#g-dialog-container').on('DOMNodeInserted', () => {
             $('.btn', '#g-dialog-container').prop('tabindex', '0');
         });
-    }
-});
+        return result;
+    };
+}
+
+export default View;


### PR DESCRIPTION
Before, only views that inherited from the HistomicsUI view would do so.

This generalizes #152.