### PR TITLE
Support annotation metadata

### DIFF
--- a/histomicsui/web_client/panels/MetadataPlot.js
+++ b/histomicsui/web_client/panels/MetadataPlot.js
@@ -29,7 +29,7 @@ var MetadataPlot = Panel.extend({
         },
         'click .h-panel-maximize': function (event) {
             this.$el.html('');
-            this.expand();
+            this.expand(event);
             this.$('.s-panel-content').addClass('in');
             let panelElem = this.$el.closest('.s-panel');
             let maximize = !panelElem.hasClass('h-panel-maximized');

--- a/histomicsui/web_client/stylesheets/dialogs/saveAnnotation.styl
+++ b/histomicsui/web_client/stylesheets/dialogs/saveAnnotation.styl
@@ -3,3 +3,23 @@
     float left
 .hui-info-list-entry
   user-select text
+.hui-annotation-metadata.hui-annotation-metadata-dialog
+  .s-panel-title-container
+    background-color #f0f0f0
+    padding 5px 6px
+    color #555
+    font-size 16px
+    font-weight bold
+    margin-top 8px
+    position relative
+    i.icon-up-open, i.icon-down-open
+      display none
+    .g-widget-metadata-add-button
+      margin-top 0
+@media (min-width: 768px)
+  .modal-dialog.hui-save-annotation-dialog
+    width inherit
+@media (min-width: 900px)
+  .modal-dialog.hui-save-annotation-dialog
+    width 70%
+    max-width 900px

--- a/histomicsui/web_client/templates/dialogs/saveAnnotation.pug
+++ b/histomicsui/web_client/templates/dialogs/saveAnnotation.pug
@@ -28,9 +28,10 @@
             i.icon-share
             | Unique ID: #{model.id}
             if model.get('_version')
-              |
+              = " "
               i.icon-angle-circled-down
               | Global Version: #{model.get('_version')}
+          .hui-annotation-metadata.hui-annotation-metadata-dialog
         if showStyleEditor
           hr
           h4 Reset the style for all point, line, and polygon elements in this annotation

--- a/histomicsui/web_client/templates/panels/metadataWidget.pug
+++ b/histomicsui/web_client/templates/panels/metadataWidget.pug
@@ -2,12 +2,12 @@ extends ./panel.pug
 
 block title
   | #[span.icon-tags] #{title}
-  if(firstKey && firstValue)
+  if panel && firstKey && firstValue
     span.g-widget-metadata-header-key-value #{firstKey+' '+firstValue+'  '}
 block controls
-  if (accessLevel >= AccessType.WRITE)
+  if accessLevel >= AccessType.WRITE
     span.s-no-panel-toggle
-      button.g-widget-metadata-add-button.btn.btn-sm.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata")
+      button.g-widget-metadata-add-button.btn.btn-sm.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata", class=panel ? '' : 'btn-primary')
         i.icon-plus
       ul.dropdown-menu.pull-right(role="menu")
         li(role="presentation")
@@ -16,6 +16,7 @@ block controls
         li(role="presentation")
           a.g-add-json-metadata
             | JSON
+  if panel
     span.s-no-panel-toggle.h-panel-maximize
       i.icon-resize-full(title="Maximize")
 

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -565,6 +565,9 @@ var ImageView = View.extend({
     },
 
     _reconcilePixelmapCategories(pixelmapId, groups, annotation) {
+        if (!annotation || !annotation.elements()) {
+            return;
+        }
         const pixelmap = annotation.elements().get(pixelmapId);
         const existingCategories = pixelmap.get('categories') || [];
         const newCategories = [];


### PR DESCRIPTION
This is shown in the annotation edit panel:

![image](https://user-images.githubusercontent.com/8781639/190479405-db1ca1ac-1c55-4049-b183-07c40e6d27c6.png)

The metadata is stored in the annotation.attributes as per the schema.

A logical extension to this would be to show annotation metadata on the item page in some manner.