### PR TITLE
Assetstore maintenance

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
   -rrequirements-dev.txt
 extras =
   analysis
-whitelist_externals =
+allowlist_externals =
   rm
   npx
 commands =
@@ -56,7 +56,7 @@ skip_install = true
 usedevelop = false
 deps =
 changedir = {toxinidir}/histomicsui/web_client
-whitelist_externals =
+allowlist_externals =
   npm
 commands =
   npm install --no-package-lock


### PR DESCRIPTION
Add some functions to facilitate assetstore maintenance.  You can check or prune abandoned files on an fs assetstore, and change the import path on a file on an fs assetstore.

Fix testing with tox 4.