### PR TITLE
Fix releasing with tox 4.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,8 +70,8 @@ passenv =
 deps =
   twine
 commands =
-  twine check {distdir}/*
-  twine upload --skip-existing {distdir}/*
+  twine check {toxworkenv}/{package_env}/dist/*
+  twine upload --skip-existing {toxworkenv}/{package_env}/dist/*
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
tox 4 no longer has `{distdir}`.  This seems like it has been replaced with `{toxworkdir}/{package_env}/dist`, which seems overly long.