### PR TITLE
Allow selecting elements by polygon

### DIFF
--- a/docs/controls.rst
+++ b/docs/controls.rst
@@ -68,8 +68,17 @@ Annotation Controls
     element is selected, the context menu will be applied to all selected
     elements.
 
+  - **m**: Show the context menu for the currently selected annotations, if
+    any.  If no annotations are selected, show the context menu for the
+    annotation under the mouse cursor.
+
   - **s**: Switch to area select mode.  Left-drag a rectangle around a group of
-    annotation elements to show the context menu for the whole group at once.
+    annotation elements to select them.
+
+  - **S**: Switch to area select polygon mode.  Draw a polygon around a group of
+    annotation elements to select them.
+
+  - **C**: Clear current selection.
 
   - **Ctrl-left click**: toggle whether an individual annotation element is
     selected.

--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -473,7 +473,12 @@ var AnnotationSelector = Panel.extend({
         });
     },
 
-    selectAnnotationByRegion() {
+    selectAnnotationByRegionActive() {
+        const btn = this.$('.h-annotation-select-by-region');
+        return !!btn.hasClass('active');
+    },
+
+    selectAnnotationByRegion(polygon) {
         const btn = this.$('.h-annotation-select-by-region');
         // listen to escape key
         $(document).on('keydown.h-annotation-select-by-region', (evt) => {
@@ -490,7 +495,7 @@ var AnnotationSelector = Panel.extend({
 
         if (!btn.hasClass('active')) {
             btn.addClass('active');
-            this.parentView.trigger('h:selectElementsByRegion');
+            this.parentView.trigger('h:selectElementsByRegion', {polygon});
         } else {
             btn.removeClass('active');
             $(document).off('keydown.h-annotation-select-by-region');

--- a/histomicsui/web_client/templates/panels/annotationSelector.pug
+++ b/histomicsui/web_client/templates/panels/annotationSelector.pug
@@ -18,7 +18,7 @@ block content
       input#h-annotation-fill-opacity(
           type="range", min="0", max="1", step="0.01", value=fillOpacity)
     .btn-group.btn-group-sm(role='group')
-      button.btn.btn-default.h-annotation-select-by-region(type='button', title='Select annotations by region.  Keyboard shortcut: s')
+      button.btn.btn-default.h-annotation-select-by-region(type='button', title='Select annotations by region.  Keyboard shortcut: s; S selects using a polygon; C clears selection')
         | #[span.icon-marquee]
 
   - var groups = _.keys(annotationGroups);


### PR DESCRIPTION
Also allow clearing the selection and add a few hotkeys.  By default, don't show the context menu after selection (it can be shown by right-click or hotkey).  Add a flag to show the context menu immediately after selecting a region of elements.