### PR TITLE
Selecting annotations and draw mode are exclusive.

### DIFF
--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -481,9 +481,7 @@ var AnnotationSelector = Panel.extend({
         // listen to escape key
         $(document).on('keydown.h-annotation-select-by-region', (evt) => {
             if (evt.keyCode === 27) {
-                btn.removeClass('active');
-                $(document).off('keydown.h-annotation-select-by-region');
-                this.parentView.trigger('h:selectElementsByRegionCancel');
+                this.selectAnnotationByRegionCancel();
             }
         });
         this.listenToOnce(this.parentView, 'h:selectedElementsByRegion', () => {
@@ -495,6 +493,13 @@ var AnnotationSelector = Panel.extend({
             btn.addClass('active');
             this.parentView.trigger('h:selectElementsByRegion', {polygon});
         } else {
+            this.selectAnnotationByRegionCancel();
+        }
+    },
+
+    selectAnnotationByRegionCancel() {
+        const btn = this.$('.h-annotation-select-by-region');
+        if (btn.hasClass('active')) {
             btn.removeClass('active');
             $(document).off('keydown.h-annotation-select-by-region');
             this.parentView.trigger('h:selectElementsByRegionCancel');

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -663,6 +663,9 @@ var DrawWidget = Panel.extend({
         }
         this.$('button.h-draw[data-type]').removeClass('active');
         if (this._drawingType) {
+            if (this.parentView.annotationSelector) {
+                this.parentView.annotationSelector.selectAnnotationByRegionCancel();
+            }
             this.$('button.h-draw[data-type="' + this._drawingType + '"]').addClass('active');
         }
     },

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -1257,6 +1257,9 @@ var ImageView = View.extend({
     },
 
     _selectElementsByRegion(evt) {
+        if (this.drawWidget && this.drawWidget.drawingType()) {
+            this.drawWidget.cancelDrawMode();
+        }
         this._selectElementsByRegionCanceled = false;
         this.viewerWidget.drawRegion(undefined, evt && evt.polygon ? 'polygon' : undefined).then((coord) => {
             if (this._selectElementsByRegionCanceled) {


### PR DESCRIPTION
Before, picking select annotations by region AND being in a draw mode (like drawing points) could both be listed as active.  Now, activating one deactivates the other.