### PR TITLE
Apply configurable sort to next and previous images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ commands:
     steps:
       - run:
           name: Install Codecov client
-          command: pip install codecov==2.1.9
+          command: pip install codecov
       - run:
           name: Upload coverage
           # Retry as codecov can be flaky
-          command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; codecov --required --disable search pycov gcov --root project --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
+          command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; codecov --disable search pycov gcov --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
 
 jobs:
   py36:


### PR DESCRIPTION
Use the .large_image_config.yaml file's itemList.defaultSort when determining the next and previous images.

This will have no effect unless a version of large_image with https://github.com/girder/large_image/pull/1099 is available.