### PR TITLE
Add annotation element metadata to the popover.

### DIFF
--- a/histomicsui/web_client/stylesheets/popover/annotationPopover.styl
+++ b/histomicsui/web_client/stylesheets/popover/annotationPopover.styl
@@ -61,6 +61,8 @@
 
       > table
         padding-left 10px
+
+      > table, .annotation-element-metadata-table > table
         display inline-block
 
         td:first-child

--- a/histomicsui/web_client/templates/popover/annotationPopoverMetadata.pug
+++ b/histomicsui/web_client/templates/popover/annotationPopoverMetadata.pug
@@ -1,0 +1,13 @@
+if element.user
+  .annotation-element-metadata-table
+    table
+      for entry in Object.entries(element.user)
+        if typeof entry[1] === 'string' || typeof entry[1] === 'number' || entry[1] instanceof String
+          tr
+            td
+              = entry[0]
+            td
+              if typeof entry[1] === 'number'
+                = parseFloat(entry[1].toPrecision(6))
+              else
+                = entry[1]

--- a/histomicsui/web_client/views/popover/AnnotationPopover.js
+++ b/histomicsui/web_client/views/popover/AnnotationPopover.js
@@ -11,6 +11,7 @@ import convertCircle from '@girder/large_image_annotation/annotations/geometry/c
 import events from '../../events';
 import View from '../View';
 import annotationPopover from '../../templates/popover/annotationPopover.pug';
+import annotationPopoverMetadata from '../../templates/popover/annotationPopoverMetadata.pug';
 import '../../stylesheets/popover/annotationPopover.styl';
 import {elementAreaAndEdgeLength} from '../utils';
 
@@ -230,6 +231,12 @@ var AnnotationPopover = View.extend({
      *   undefined.
      */
     _elementAdditionalValues(element, annotation) {
+        if (element && element.toJSON && annotation && annotation.toJSON) {
+            return annotationPopoverMetadata({
+                annotation: annotation.toJSON(),
+                element: element.toJSON()
+            });
+        }
     },
 
     /**


### PR DESCRIPTION
The metadata on an element's user property only appears if it is associated with a top level key and has a value that is a string or a number.  Numbers are limited in precision to six digits.

A future improvement would be to show metadata based on the config file, including styling based on datatype information.