### PR TITLE
To make it easier to deploy in an Iframe, allow token auth.

### DIFF
--- a/histomicsui/web_client/app.js
+++ b/histomicsui/web_client/app.js
@@ -6,7 +6,7 @@ import '@girder/fontello/dist/css/fontello.css';
 
 import GirderApp from '@girder/core/views/App';
 import eventStream from '@girder/core/utilities/EventStream';
-import {getCurrentUser} from '@girder/core/auth';
+import {getCurrentUser, setCurrentToken} from '@girder/core/auth';
 import {splitRoute} from '@girder/core/misc';
 
 import router from './router';
@@ -16,8 +16,22 @@ import bindRoutes from './routes';
 import layoutTemplate from './templates/layout/layout.pug';
 import './stylesheets/layout/layout.styl';
 
+function getQuery() {
+    var query = document.location.search.replace(/(^\?)/, '').split('&').map(function (n) {
+        n = n.split('=');
+        if (n[0]) {
+            this[decodeURIComponent(n[0].replace(/\+/g, '%20'))] = decodeURIComponent(n[1].replace(/\+/g, '%20'));
+        }
+        return this;
+    }.bind({}))[0];
+    return query;
+}
+
 var App = GirderApp.extend({
     initialize(settings) {
+        if (getQuery().token) {
+            setCurrentToken(getQuery().token);
+        }
         this.settings = settings;
         return GirderApp.prototype.initialize.apply(this, arguments);
     },


### PR DESCRIPTION
Specifically, something like <url>/histomics?token=<token>#?image=<id> will load the histomics interface authenticated with the token (assuming the token is a valid girder token).  Note than in the Iframe context, the histomics site must be on the same domain as the host or served via https (and probably have 3rd party cookies enabled) or this won't provide cookies to allow reading private images (tiles and thumbnails).