### PR TITLE
Show resource paths in girder search pages.

### DIFF
--- a/histomicsui/web_client/main.js
+++ b/histomicsui/web_client/main.js
@@ -11,6 +11,7 @@ import * as histomicsui from '@girder/histomicsui';
 import './views/itemList';
 import './views/itemPage';
 import './views/HierarchyWidget';
+import './views/searchResultsView';
 
 import ConfigView from './views/body/ConfigView';
 

--- a/histomicsui/web_client/stylesheets/views/searchResultsView.styl
+++ b/histomicsui/web_client/stylesheets/views/searchResultsView.styl
@@ -1,0 +1,5 @@
+span.g-hui-search-result-resource-path
+  color black
+
+span.g-hui-search-result-resource-path::before
+  content "\00a0\00a0\2014\00a0\00a0"

--- a/histomicsui/web_client/views/searchResultsView.js
+++ b/histomicsui/web_client/views/searchResultsView.js
@@ -1,0 +1,49 @@
+import $ from 'jquery';
+
+import {wrap} from '@girder/core/utilities/PluginUtils';
+import {restRequest} from '@girder/core/rest';
+import SearchResultsView from '@girder/core/views/body/SearchResultsView';
+
+import '../stylesheets/views/searchResultsView.styl';
+
+function addResourcePaths(v) {
+    if (!v._results || !v._results.length) {
+        return;
+    }
+    const payload = {};
+    payload[v._type] = v._results.map((r) => r._id);
+    const resources = JSON.stringify(payload);
+    restRequest({
+        type: 'POST',
+        contentType: 'application/json',
+        processData: false,
+        url: 'resource/paths',
+        error: null,
+        data: resources
+    }).done((resp) => {
+        const payload = {};
+        payload[v._type] = v._results.map((r) => r._id);
+        if (resources !== JSON.stringify(payload)) {
+            return;
+        }
+        console.log(payload, resp);
+        v._results.forEach((doc, idx) => {
+            $(v.$el.find('.g-search-result')[idx]).append($('<span class="g-hui-search-result-resource-path">').text(resp[v._type][doc._id]));
+        });
+    });
+}
+
+wrap(SearchResultsView, 'render', function (render) {
+    render.call(this);
+    this._request.done(() => {
+        Object.values(this._subviews).forEach((v) => {
+            v._origrender = v.render;
+            v.render = function () {
+                v._origrender();
+                addResourcePaths(v);
+                return v;
+            };
+            addResourcePaths(v);
+        });
+    });
+});

--- a/tox.ini
+++ b/tox.ini
@@ -82,12 +82,15 @@ passenv =
   TWINE_USERNAME
   TWINE_PASSWORD
   TWINE_REPOSITORY_URL
-  CIRCLE_BRANCH
+allowlist_externals =
+  git
 deps =
   build
   twine
 commands =
+  git status
   python -m build
+  git status
   twine check dist/*
   twine upload --skip-existing dist/*
 


### PR DESCRIPTION
If you have multiple resources with the same name, the search page wasn't useful.