### PR TITLE
Adjust position and z-index of region control dropdown

### DIFF
--- a/histomicsui/web_client/stylesheets/layout/layout.styl
+++ b/histomicsui/web_client/stylesheets/layout/layout.styl
@@ -106,4 +106,5 @@ body.hui-body[view-mode="dark"]
         background-color #4672cc
 
   .region-dropdown
-    z-index 100
+    position relative
+    z-index auto


### PR DESCRIPTION
This changes the z-index and position of the second region control's drop down button so it doesn't cover the first region control's drop down menu, an issue raised [here](https://github.com/girder/slicer_cli_web/issues/236)