### PR TITLE
Improve plots

### DIFF
--- a/histomicsui/web_client/templates/dialogs/metadataPlot.pug
+++ b/histomicsui/web_client/templates/dialogs/metadataPlot.pug
@@ -22,7 +22,7 @@
             {key: 'r', label: 'Radius'},
             {key: 'c', label: 'Color'},
             {key: 's', label: 'Symbol', string: true, comment: 'Grouping for violin plots'}]
-        for series in seriesList
+        for series, seriesidx in seriesList
           .form-group
             label(for='h-plot-series-' + series.key) #{series.label}
             if series.comment
@@ -30,9 +30,10 @@
             select.form-control(id='h-plot-series-' + series.key)
               if !series.number
                 option(value='_none_', selected=plotConfig[series.key] === undefined) None
-              each opt in plotOptions
+              each opt, optidx in plotOptions
                 if (!series.number || opt.type === 'number') && (!series.string || opt.type === 'string' || opt.distinct)
                   - var selected = plotConfig[series.key] === opt.key
+                  - if (plotConfig[series.key] === undefined && series.number === true && optidx === seriesidx) { selected = true; }
                   option(value=opt.key, selected=selected) #{opt.title}
         .form-group
           label(for='h-plot-folder')

--- a/histomicsui/web_client/templates/panels/metadataPlot.pug
+++ b/histomicsui/web_client/templates/panels/metadataPlot.pug
@@ -10,4 +10,4 @@ block controls
       i.icon-resize-full(title="Maximize")
 
 block content
-  .h-metadata-plot-area
+  #h-metadata-plot.h-metadata-plot-area


### PR DESCRIPTION
Restrict to a reasonable number of significant figures.

Always show name and annotation name when there are multiples.

Show bounding box region thumbnails in the plot hover box.

Reflect selections on the plot on annotation elements and vice versa.