### PR TITLE
Move away from bootstrap colorpicker

### DIFF
--- a/histomicsui/web_client/dialogs/editElement.js
+++ b/histomicsui/web_client/dialogs/editElement.js
@@ -1,4 +1,5 @@
 import tinycolor from 'tinycolor2';
+import JsColor from '@eastdesire/jscolor';
 
 import EditHeatmapOrGridDataContainer from '../vue/components/EditHeatmapOrGridDataContainer.vue';
 
@@ -24,7 +25,17 @@ var EditElement = View.extend({
             })
         ).girderModal(this);
         this.createVueModal();
-        this.$('.h-colorpicker').colorpicker();
+
+        const lineColorElement = this.$('#h-element-line-color')[0];
+        const fillColorElement = this.$('#h-element-fill-color')[0];
+        (() => new JsColor(lineColorElement, {
+            format: 'rgba',
+            value: this.annotationElement.toJSON().lineColor
+        }))();
+        (() => new JsColor(fillColorElement, {
+            format: 'rgba',
+            value: this.annotationElement.toJSON().fillColor
+        }))();
         return this;
     },
 

--- a/histomicsui/web_client/dialogs/editStyleGroups.js
+++ b/histomicsui/web_client/dialogs/editStyleGroups.js
@@ -1,4 +1,5 @@
 import tinycolor from 'tinycolor2';
+import JsColor from '@eastdesire/jscolor';
 
 import StyleModel from '../models/StyleModel';
 import editStyleGroups from '../templates/dialogs/editStyleGroups.pug';
@@ -27,12 +28,12 @@ const EditStyleGroups = View.extend({
         'click #h-import-replace': '_toggleImportReplace',
         'change #h-import-groups': '_importGroups',
         'change .h-style-def': '_updateStyle',
-        'changeColor .h-colorpicker': '_updateStyle',
+        'change .h-colorpicker': '_updateStyle',
         'change select': '_setStyle'
     },
 
     render() {
-        this.$('.h-colorpicker').colorpicker('destroy');
+        // this.$('.h-colorpicker').colorpicker('destroy');
         this.$el.html(
             editStyleGroups({
                 collection: this.collection,
@@ -41,7 +42,19 @@ const EditStyleGroups = View.extend({
                 user: getCurrentUser() || {}
             })
         );
-        this.$('.h-colorpicker').colorpicker();
+        const inputLine = $('#h-element-line-color')[0];
+        const inputFill = $('#h-element-fill-color')[0];
+
+        // Initialize the color picker inputs with JsColor using the constructor.
+        // We don't need to track the objects created.
+        (() => new JsColor(inputLine, {
+            format: 'rgba',
+            value: this.model.get('lineColor')
+        }))();
+        (() => new JsColor(inputFill, {
+            format: 'rgba',
+            value: this.model.get('fillColor')
+        }))();
         return this;
     },
 

--- a/histomicsui/web_client/dialogs/saveAnnotation.js
+++ b/histomicsui/web_client/dialogs/saveAnnotation.js
@@ -1,4 +1,5 @@
 import tinycolor from 'tinycolor2';
+import JsColor from '@eastdesire/jscolor';
 
 import MetadataWidget from '../panels/MetadataWidget';
 import '../stylesheets/dialogs/saveAnnotation.styl';
@@ -216,13 +217,13 @@ var SaveAnnotation = View.extend({
         'click .h-cancel': 'cancel',
 
         'input #h-annotation-fill-color': 'checkFixedIfPresent',
-        'changeColor #h-annotation-colorpicker-fill-color': 'checkFixedIfPresent',
+        'change #h-annotation-colorpicker-fill-color': 'checkFixedIfPresent',
         'change #h-annotation-fill-color-func-list': 'changeFillColorFunc',
         'input #h-annotation-fill-color-min-val': () => $('.h-functional-value #h-annotation-fill-color-min-setval').prop('checked', true),
         'input #h-annotation-fill-color-max-val': () => $('.h-functional-value #h-annotation-fill-color-max-setval').prop('checked', true),
 
         'input #h-annotation-line-color': 'checkFixedIfPresent',
-        'changeColor #h-annotation-colorpicker-line-color': 'checkFixedIfPresent',
+        'change #h-annotation-colorpicker-line-color': 'checkFixedIfPresent',
         'change #h-annotation-line-color-func-list': 'changeLineColorFunc',
         'input #h-annotation-line-color-min-val': () => $('.h-functional-value #h-annotation-line-color-min-setval').prop('checked', true),
         'input #h-annotation-line-color-max-val': () => $('.h-functional-value #h-annotation-line-color-max-setval').prop('checked', true),
@@ -232,10 +233,10 @@ var SaveAnnotation = View.extend({
 
     render() {
         // clean up old colorpickers when rerendering
-        const hColorPicker = this.$('.h-colorpicker');
-        if (hColorPicker.colorpicker) {
-            hColorPicker.colorpicker('destroy');
-        }
+        // const hColorPicker = this.$('.h-colorpicker');
+        // if (hColorPicker.colorpicker) {
+        //     hColorPicker.colorpicker('destroy');
+        // }
 
         let elementTypes = [];
         if (this.annotation.get('annotation').elements) {
@@ -309,7 +310,29 @@ var SaveAnnotation = View.extend({
                 defaultStyles
             })
         ).girderModal(this);
-        this.$('.h-colorpicker').colorpicker();
+
+        const lc = 'lineColor';
+        const fc = 'fillColor';
+        const styleFuncs = this.annotation._styleFuncs;
+        // There are 6 possible colorpickers we may need to initialize
+        // Ids can be:
+        const colorPickerOpts = {
+            '#h-annotation-line-color': defaultStyles[lc],
+            '#h-annotation-fill-color': defaultStyles[fc],
+            '#h-annotation-line-color-max': styleFuncs[lc].maxColor || defaultStyles[lc],
+            '#h-annotation-line-color-min': styleFuncs[lc].minColor || defaultStyles[lc],
+            '#h-annotation-fill-color-max': styleFuncs[fc].maxColor || defaultStyles[fc],
+            '#h-annotation-fill-color-min': styleFuncs[fc].minColor || defaultStyles[fc]
+        };
+        Object.keys(colorPickerOpts).forEach((id) => {
+            const input = this.$(id)[0] || null;
+            if (input) {
+                (() => new JsColor(input, {
+                    format: 'rgba',
+                    value: colorPickerOpts[id]
+                }))();
+            }
+        });
 
         if (this.annotation.id) {
             if (!this.annotation.meta) {

--- a/histomicsui/web_client/dialogs/saveAnnotation.js
+++ b/histomicsui/web_client/dialogs/saveAnnotation.js
@@ -232,7 +232,10 @@ var SaveAnnotation = View.extend({
 
     render() {
         // clean up old colorpickers when rerendering
-        this.$('.h-colorpicker').colorpicker('destroy');
+        const hColorPicker = this.$('.h-colorpicker');
+        if (hColorPicker.colorpicker) {
+            hColorPicker.colorpicker('destroy');
+        }
 
         let elementTypes = [];
         if (this.annotation.get('annotation').elements) {

--- a/histomicsui/web_client/package-lock.json
+++ b/histomicsui/web_client/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@eastdesire/jscolor": "^2.5.2",
                 "@girder/core": "^5.0.0-beta.2",
                 "@vue/compiler-sfc": "^3.2.33",
                 "bootstrap-submenu": "^2.0.4",
@@ -134,6 +135,12 @@
             "bin": {
                 "findup": "bin/findup.js"
             }
+        },
+        "node_modules/@eastdesire/jscolor": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@eastdesire/jscolor/-/jscolor-2.5.2.tgz",
+            "integrity": "sha512-WPldVg9Z0tXDOROpbeLslv0Uj/CPgou+6GVMPZs2T+nKOkeBHYVZNfugixBhGzYWKWUumTzmTkLgnCVWlNwl2w==",
+            "license": "GPL-3.0-or-later"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.20.2",
@@ -10178,6 +10185,11 @@
             "requires": {
                 "commander": "^2.15.1"
             }
+        },
+        "@eastdesire/jscolor": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@eastdesire/jscolor/-/jscolor-2.5.2.tgz",
+            "integrity": "sha512-WPldVg9Z0tXDOROpbeLslv0Uj/CPgou+6GVMPZs2T+nKOkeBHYVZNfugixBhGzYWKWUumTzmTkLgnCVWlNwl2w=="
         },
         "@esbuild/aix-ppc64": {
             "version": "0.20.2",

--- a/histomicsui/web_client/package.json
+++ b/histomicsui/web_client/package.json
@@ -26,6 +26,7 @@
         "test": "playwright test"
     },
     "dependencies": {
+        "@eastdesire/jscolor": "^2.5.2",
         "@girder/core": "^5.0.0-beta.2",
         "@vue/compiler-sfc": "^3.2.33",
         "bootstrap-submenu": "^2.0.4",

--- a/histomicsui/web_client/stylesheets/dialogs/editStyleGroups.styl
+++ b/histomicsui/web_client/stylesheets/dialogs/editStyleGroups.styl
@@ -1,6 +1,9 @@
 select.h-group-name
   appearance none
 
+.h-colorpicker
+  width 100%
+
 .h-btn-left
   float left
 
@@ -13,3 +16,6 @@ select.h-group-name
 #h-import-replace
   margin 0 0 0 5px
   vertical-align middle
+
+#h-element-fill-color, #h-element-line-color
+  border-radius 3px

--- a/histomicsui/web_client/templates/dialogs/editElement.pug
+++ b/histomicsui/web_client/templates/dialogs/editElement.pug
@@ -28,17 +28,11 @@ else
             .form-group
               label(for='h-element-line-color') Line color
               .input-group.h-colorpicker
-                input#h-element-line-color.input-sm.form-control(
-                  type='text', value=element.lineColor)
-                span.input-group-addon
-                  i
+                input#h-element-line-color.input-sm.form-control(type='text')
             .form-group
               label(for='h-element-fill-color') Fill color
               .input-group.h-colorpicker
-                input#h-element-fill-color.input-sm.form-control(
-                  type='text', value=element.fillColor)
-                span.input-group-addon
-                  i
+                input#h-element-fill-color.input-sm.form-control(type='text')
             .g-validation-failed-message.hidden
       .modal-footer
         button.btn.btn-default(type='button', data-dismiss='modal') Cancel

--- a/histomicsui/web_client/templates/dialogs/editStyleGroups.pug
+++ b/histomicsui/web_client/templates/dialogs/editStyleGroups.pug
@@ -39,17 +39,11 @@
         .form-group
           label(for='h-element-line-color') Line color
           .input-group.h-colorpicker
-            input#h-element-line-color.input-sm.form-control(
-              type='text', value=model.get('lineColor'))
-            span.input-group-addon
-              i
+            input#h-element-line-color.input-sm.form-control.h-colorpicker-line()
         .form-group
           label(for='h-element-fill-color') Fill color
           .input-group.h-colorpicker
-            input#h-element-fill-color.input-sm.form-control(
-              type='text', value=model.get('fillColor'))
-            span.input-group-addon
-              i
+            input#h-element-fill-color.input-sm.form-control()
         .g-validation-failed-message.hidden
       .modal-footer
         button#h-reset-defaults.btn.btn-sm.btn-default.h-btn-left(type='button') Reset to Defaults

--- a/histomicsui/web_client/templates/dialogs/saveAnnotation.pug
+++ b/histomicsui/web_client/templates/dialogs/saveAnnotation.pug
@@ -4,9 +4,7 @@ mixin functional(name, key, title, color)
     - let anyFuncs = !!Object.keys(styleableFuncs || {}).length;
     if !anyFuncs
       .input-group.h-colorpicker(id='h-annotation-colorpicker-' + name)
-        input.input-sm.form-control(id='h-annotation-' + name, type='text', value=defaultStyles[key])
-        span.input-group-addon
-          i
+        input.input-sm.form-control(id='h-annotation-' + name, type='text')
     else
       .row
         .col-sm-2
@@ -14,9 +12,7 @@ mixin functional(name, key, title, color)
           label.unstyled(for='h-annotation-' + name + '-fixed') Constant
         .col-sm-10
           .input-group.h-colorpicker(id='h-annotation-colorpicker-' + name)
-            input.input-sm.form-control(id='h-annotation-' + name, type='text', value=defaultStyles[key])
-            span.input-group-addon
-              i
+            input.input-sm.form-control(id='h-annotation-' + name, type='text')
       .row
         .col-sm-2
           input(id='h-annotation-' + name + '-func', type='radio', name=name + '-set', checked=styleFuncs[key].useFunc ? 'checked' : undefined)
@@ -31,9 +27,7 @@ mixin functional(name, key, title, color)
         .col-sm-3
           | minimum
           .input-group.h-colorpicker
-            input.input-sm.form-control(id='h-annotation-' + name + '-min', type='text', value=styleFuncs[key].minColor || defaultStyles[key])
-            span.input-group-addon
-              i
+            input.input-sm.form-control(id='h-annotation-' + name + '-min', type='text')
         .col-sm-2
           div
             input(id='h-annotation-' + name + '-min-auto', type='radio', name=name + '-min-set', checked=styleFuncs[key].minSet ? undefined : 'checked')
@@ -44,9 +38,7 @@ mixin functional(name, key, title, color)
         .col-sm-3
           | maximum
           .input-group.h-colorpicker
-            input.input-sm.form-control(id='h-annotation-' + name + '-max', type='text', value=styleFuncs[key].maxColor || defaultStyles[key])
-            span.input-group-addon
-              i
+            input.input-sm.form-control(id='h-annotation-' + name + '-max', type='text')
         .col-sm-2
           div
             input(id='h-annotation-' + name + '-max-auto', type='radio', name=name + '-max-set', checked=styleFuncs[key].maxSet ? undefined : 'checked')

--- a/histomicsui/web_client/templates/dialogs/saveAnnotation.pug
+++ b/histomicsui/web_client/templates/dialogs/saveAnnotation.pug
@@ -55,7 +55,13 @@ mixin functional(name, key, title, color)
             input(id='h-annotation-' + name + '-max-setval', type='radio', name=name + '-max-set', checked=styleFuncs[key].maxSet ? 'checked' : undefined)
             input(id='h-annotation-' + name + '-max-val', type='number', step='any', value=styleFuncs[key].maxValue)
 
-- var timestamp = moment().format('YYYY-MM-DD HH:mm')
+- var date = new Date()
+- var year = date.getFullYear()
+- var month = String(date.getMonth() + 1).padStart(2, '0')
+- var day = String(date.getDate()).padStart(2, '0')
+- var hours = String(date.getHours()).padStart(2, '0')
+- var minutes = String(date.getMinutes()).padStart(2, '0')
+- var timestamp = year + '-' + month + '-' + day + ' ' + hours + ':' + minutes
 - var defaultName = 'Annotation '+ timestamp
 .modal-dialog(role='document')
   .modal-content


### PR DESCRIPTION
## Changes

This PR adds a dependency on https://github.com/eastdesire/jscolor to replace the bootstrap colorpicker. The style is different from the old colorpicker but supports an alpha channel. Colors can be input via the widget or the input field using either hex or rgb(a).

![image](https://github.com/user-attachments/assets/99d864bf-5048-45a1-9fb3-54dca8d54626)

![image](https://github.com/user-attachments/assets/7a1cb934-6164-499f-ba37-8943400d2ef6)


