### PR TITLE
Fix importing from `large_image` namespace

### DIFF
--- a/histomicsui/web_client/panels/FrameSelectorWidget.js
+++ b/histomicsui/web_client/panels/FrameSelectorWidget.js
@@ -13,7 +13,7 @@ var FrameSelectorWidget = Panel.extend({
         const DualInput = girder.plugins.large_image.widgets.DualInput;
         const CompositeLayers = girder.plugins.large_image.widgets.CompositeLayers;
         const HistogramEditor = girder.plugins.large_image.widgets.HistogramEditor;
-        const PresetsMenu = girder.plugins.large_image.vue.components.PresetsMenu;
+        const PresetsMenu = girder.plugins.large_image.vue.PresetsMenu;
         const colors = girder.plugins.large_image.widgets.colors;
         // if not a multi frame image, don't show (this means we can't do
         // band-only work on hyperspectral data, so we may want to change this

--- a/histomicsui/web_client/panels/OverviewWidget.js
+++ b/histomicsui/web_client/panels/OverviewWidget.js
@@ -93,7 +93,7 @@ var OverviewWidget = Panel.extend({
         params.layer.autoshareRenderer = false;
         this._tileLayer = this.viewer.createLayer('osm', params.layer);
         if (this.parentViewer._layer && this.parentViewer._layer.setFrameQuad) {
-            const setFrameQuad = girder.plugins.large_image.views.imageViewerWidget.setFrameQuad;
+            const setFrameQuad = girder.plugins.large_image.utils.setFrameQuad;
             setFrameQuad((this.parentViewer._layer.setFrameQuad.status || {}).tileinfo, this._tileLayer, (this.parentViewer._layer.setFrameQuad.status || {}).options);
             this._tileLayer.setFrameQuad(0);
         }


### PR DESCRIPTION
Changes some lines to reflect the actual structure of the `girder.plugins.large_image` object.