### PR TITLE
Add submenu plugin to correct jQuery

### DIFF
--- a/histomicsui/web_client/package-lock.json
+++ b/histomicsui/web_client/package-lock.json
@@ -2036,7 +2036,8 @@
         "node_modules/bootstrap-submenu": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/bootstrap-submenu/-/bootstrap-submenu-2.0.4.tgz",
-            "integrity": "sha512-crTxeQG4fCu2B15+OIIhwSDPn90D+wY6rIDgnD+aLALsRN5f471XzCn32Ej0qKm8wqPn66Vxl3Q4o4qaaRhIzg=="
+            "integrity": "sha512-crTxeQG4fCu2B15+OIIhwSDPn90D+wY6rIDgnD+aLALsRN5f471XzCn32Ej0qKm8wqPn66Vxl3Q4o4qaaRhIzg==",
+            "license": "MIT"
         },
         "node_modules/bootstrap-switch": {
             "version": "3.3.5",

--- a/histomicsui/web_client/package.json
+++ b/histomicsui/web_client/package.json
@@ -37,8 +37,8 @@
         "sinon": "^2.1.0",
         "tinycolor2": "~1.4.1",
         "url-search-params-polyfill": "^8.1.1",
-        "vue": "^2.7.16",
         "uuid": "^8.3.2",
+        "vue": "^2.7.16",
         "vue-color": "^2.8.1",
         "vue-loader": "~15.9.8",
         "vue-template-compiler": "~2.6.14"
@@ -98,7 +98,10 @@
             "vue/require-prop-types": "off"
         },
         "root": true,
-        "ignorePatterns": ["dist/**", "dist-app/**"],
+        "ignorePatterns": [
+            "dist/**",
+            "dist-app/**"
+        ],
         "globals": {
             "girder": "readonly"
         }

--- a/histomicsui/web_client/views/layout/HeaderAnalysesView.js
+++ b/histomicsui/web_client/views/layout/HeaderAnalysesView.js
@@ -1,28 +1,22 @@
+// Importing the bootstrap-submenu jQuery plugin immediately
+// runs an IIFE, which modifies the global jQuery (i.e. require('jquery')).
+// We'd prefer to only use girder.$ as the jquery instance in this view, but
+// in order to use the jquery plugin, we have to bring in an additional instance.
+// Ideally, this is a temporary measure. This is documented in Github.
+// See: https://github.com/DigitalSlideArchive/HistomicsUI/issues/454
+import $ from 'jquery';
+
 import events from '../../events';
 import router from '../../router';
 import View from '../View';
 import headerAnalysesTemplate from '../../templates/layout/headerAnalyses.pug';
 import '../../stylesheets/layout/headerAnalyses.styl';
 
-// Importing the bootstrap-submenu jQuery plugin immediately
-// runs an IIFE, which modifies the global jQuery (i.e. window.jQuery).
-// We can temporarily point window.jQuery to girder.$, so we add the
-// plugin to the instance of jQuery stored on the girder global.
-// See: https://github.com/DigitalSlideArchive/HistomicsUI/issues/454
-const $ = girder.$;
-const windowJQuery = window.jQuery;
-window.jQuery = $;
-
 import 'bootstrap-submenu/dist/js/bootstrap-submenu'; // eslint-disable-line
 import 'bootstrap-submenu/dist/css/bootstrap-submenu.css'; // eslint-disable-line
 
-console.log('help');
-if (typeof $.fn.submenupicker === 'function') {
-    console.log('success');
-    window.jQuery = windowJQuery;
-}
-
 const _ = girder._;
+const _$ = girder.$;
 const {restRequest} = girder.rest;
 
 var HeaderUserView = View.extend({
@@ -41,7 +35,7 @@ var HeaderUserView = View.extend({
             restRequest({
                 url: 'slicer_cli_web/docker_image'
             }).then((analyses) => {
-                const maxRows = Math.max(5, Math.floor((($('.h-image-view-body').height() || 0) - 8) / 26));
+                const maxRows = Math.max(5, Math.floor(((_$('.h-image-view-body').height() || 0) - 8) / 26));
                 if (_.keys(analyses || {}).length > 0) {
                     this.$el.removeClass('hidden');
                     this.$el.html(headerAnalysesTemplate({
@@ -61,7 +55,7 @@ var HeaderUserView = View.extend({
     },
     _setAnalysis(evt) {
         evt.preventDefault();
-        var target = $(evt.currentTarget).data();
+        var target = _$(evt.currentTarget).data();
 
         router.setQuery('analysis', target.api, {trigger: true});
     }

--- a/histomicsui/web_client/views/layout/HeaderAnalysesView.js
+++ b/histomicsui/web_client/views/layout/HeaderAnalysesView.js
@@ -8,17 +8,20 @@ import '../../stylesheets/layout/headerAnalyses.styl';
 // runs an IIFE, which modifies the global jQuery (i.e. window.jQuery).
 // We can temporarily point window.jQuery to girder.$, so we add the
 // plugin to the instance of jQuery stored on the girder global.
+// See: https://github.com/DigitalSlideArchive/HistomicsUI/issues/454
+const $ = girder.$;
 const windowJQuery = window.jQuery;
-window.jQuery = girder.$;
+window.jQuery = $;
 
 import 'bootstrap-submenu/dist/js/bootstrap-submenu'; // eslint-disable-line
 import 'bootstrap-submenu/dist/css/bootstrap-submenu.css'; // eslint-disable-line
 
-if (typeof girder.$.fn.submenupicker === 'function') {
+console.log('help');
+if (typeof $.fn.submenupicker === 'function') {
+    console.log('success');
     window.jQuery = windowJQuery;
 }
 
-const $ = girder.$;
 const _ = girder._;
 const {restRequest} = girder.rest;
 

--- a/histomicsui/web_client/views/layout/HeaderAnalysesView.js
+++ b/histomicsui/web_client/views/layout/HeaderAnalysesView.js
@@ -43,6 +43,12 @@ var HeaderUserView = View.extend({
                         maxRows: maxRows
                     }));
                     $('.h-analyses-dropdown-link').submenupicker();
+                    // Restore the "fully collapse" functionality
+                    $('.h-analyses-dropdown-link').on('click', function () {
+                        $('.dropdown-submenu').each(function () {
+                            $(this).removeClass('open');
+                        });
+                    });
                 } else {
                     this.$el.addClass('hidden');
                 }
@@ -55,7 +61,10 @@ var HeaderUserView = View.extend({
     },
     _setAnalysis(evt) {
         evt.preventDefault();
-        var target = _$(evt.currentTarget).data();
+        var target = $(evt.currentTarget).data();
+        $('.dropdown-submenu').each(function () {
+            $(this).removeClass('open');
+        });
 
         router.setQuery('analysis', target.api, {trigger: true});
     }

--- a/histomicsui/web_client/views/layout/HeaderAnalysesView.js
+++ b/histomicsui/web_client/views/layout/HeaderAnalysesView.js
@@ -4,11 +4,22 @@ import View from '../View';
 import headerAnalysesTemplate from '../../templates/layout/headerAnalyses.pug';
 import '../../stylesheets/layout/headerAnalyses.styl';
 
-import 'bootstrap-submenu/dist/js/bootstrap-submenu';
-import 'bootstrap-submenu/dist/css/bootstrap-submenu.css';
+// Importing the bootstrap-submenu jQuery plugin immediately
+// runs an IIFE, which modifies the global jQuery (i.e. window.jQuery).
+// We can temporarily point window.jQuery to girder.$, so we add the
+// plugin to the instance of jQuery stored on the girder global.
+const windowJQuery = window.jQuery;
+window.jQuery = girder.$;
 
-const _ = girder._;
+import 'bootstrap-submenu/dist/js/bootstrap-submenu'; // eslint-disable-line
+import 'bootstrap-submenu/dist/css/bootstrap-submenu.css'; // eslint-disable-line
+
+if (typeof girder.$.fn.submenupicker === 'function') {
+    window.jQuery = windowJQuery;
+}
+
 const $ = girder.$;
+const _ = girder._;
 const {restRequest} = girder.rest;
 
 var HeaderUserView = View.extend({
@@ -34,7 +45,7 @@ var HeaderUserView = View.extend({
                         analyses: analyses || {},
                         maxRows: maxRows
                     }));
-                    this.$('.h-analyses-dropdown-link').submenupicker();
+                    $('.h-analyses-dropdown-link').submenupicker();
                 } else {
                     this.$el.addClass('hidden');
                 }


### PR DESCRIPTION
### Changes

Due to how the `bootstrap-submenu` plugin adds functionality to jQuery, it does not install itself properly on `girder.$`. This PR adds an additional import of `$ from 'jquery`, so that we can correctly initialize the dropdown menus with the plugin.

The downside is that now this view maintains two different instances of jquery (`$` and `girder.$` as `_$`).

#### Alternative approaches explored
I looked for other packages that could offer additional functionality, but could not find any that were relatively plug and play. Ideally we'd not want to rewrite much code or implement complex UI logic to hold up release of Girder 5. I came across libraries like popper.js and Floating UI, which provide tools for positioning UI elements, but it seemed like those weren't good fits for this.

I considered forking the `bootstrap-submenu` plugin, and making it run not as an IIFE, but exporting a function to set up the plugin on an arbitrary jquery instance. I don't think the overhead of maintaining such a patch is worth it for this single use case, and the patch itself was probably too complicated to try and pull off at run time.

#### Alternative approaches not explored
Adding the plugin to jquery in girder core, before it exports `$` as part of the `girder` global. This might work, and it could have the advantage of offering this plugin to all plugins, but as far as I'm aware, only HistomicsUI uses it, so maybe that approach is overkill.

### Follow-up 
I have opened #454 to track implementing a better solution for the dropdown analyses menus.