### PR TITLE
Run release job on girder-5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,4 +256,6 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              only:
+                - master
+                - girder-5

--- a/.circleci/get_version.py
+++ b/.circleci/get_version.py
@@ -1,0 +1,19 @@
+import re
+
+import setuptools_scm
+
+
+def main():
+    version = setuptools_scm.get_version()
+    expected_version_regex = r'(\d+\.\d+\.\d+)a(\d+).+$'
+    match = re.match(expected_version_regex, version)
+    if not match:
+        error_message = f'Version {version} does not match the expected format'
+        raise ValueError(error_message)
+    base_version = match.group(1)
+    alpha_version = match.group(2)
+    print(f'{base_version}a{alpha_version}')
+
+
+if __name__ == '__main__':
+    main()

--- a/.circleci/publish_pypi.sh
+++ b/.circleci/publish_pypi.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+export SETUPTOOLS_SCM_PRETEND_VERSION=`python -m setuptools_scm | sed "s/.* //"`
+if [ "${CIRCLE_BRANCH-:}" = "master" ]; then
+    export SETUPTOOLS_SCM_PRETEND_VERSION=`echo $SETUPTOOLS_SCM_PRETEND_VERSION | sed "s/\+.*$//"`
+elif [ "${CIRCLE_BRANCH-:}" = "girder-5" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    pip install setuptools-scm
+    export SETUPTOOLS_SCM_PRETEND_VERSION=$(python "$SCRIPT_DIR/get_version.py")
+fi
+
+python -m build
+twine check dist/*
+twine upload --skip-existing dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,6 @@ graft histomicsui
 graft docs
 prune test
 global-exclude *.py[co] *.cmake __pycache__ node_modules
+
+prune histomicsui/web_client
+recursive-include histomicsui/web_client/dist/*

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def prerelease_local_scheme(version):
     """
     from setuptools_scm.version import get_local_node_and_date
 
-    if os.getenv('CIRCLE_BRANCH') in ('master', ):
+    if os.getenv('CIRCLE_BRANCH') in ('master', 'girder-5'):
         return ''
     else:
         return get_local_node_and_date(version)

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,10 @@ commands =
   npm run format
 
 [testenv:release]
+allowlist_externals =
+    {toxinidir}/.circleci/publish_pypi.sh
+skip_install = true
+skipsdist = true
 passenv =
   TWINE_USERNAME
   TWINE_PASSWORD
@@ -97,11 +101,11 @@ passenv =
   CIRCLE_BRANCH
 deps =
   build
+  setuptools-git
+  setuptools-scm
   twine
 commands =
-  python -m build
-  twine check dist/*
-  twine upload --skip-existing dist/*
+    {toxinidir}/.circleci/publish_pypi.sh
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
This draws inspiration from the [script](https://github.com/girder/large_image/blob/dc21aeabf1f0f77ef233bd6fd9f8c963e9ebcf2a/.circleci/release_pypi.sh#L7-L13) used to publish large image, with some differences.

I intend to manually create tag `v2.0.0a1` on the `girder-5` branch before this is merged. On merge I expect `v2.0.0a2` to be created automatically.