### PR TITLE
Use an option flag rather than silent in some bootstrap calls

### DIFF
--- a/histomicsui/web_client/dialogs/saveAnnotation.js
+++ b/histomicsui/web_client/dialogs/saveAnnotation.js
@@ -467,26 +467,26 @@ var SaveAnnotation = View.extend({
 
         // all valid
         if (setFillColor || setLineColor || setLineWidth) {
-            this.annotation.elements().each((element, idx) => { /* eslint-disable backbone/no-silent */
+            this.annotation.elements().each((element, idx) => {
                 if (setFillColor) {
                     if (setFillColor === 'func') {
                         fillColor = colorFromFunc(element, idx, fillColorParam, this._styleableFuncs[fillColorParam.key]);
                     }
-                    element.set('fillColor', fillColor, {silent: true});
+                    element.set('fillColor', fillColor, {delaySave: true});
                 }
                 if (setLineColor) {
                     if (setLineColor === 'func') {
                         lineColor = colorFromFunc(element, idx, lineColorParam, this._styleableFuncs[lineColorParam.key]);
                     }
-                    element.set('lineColor', lineColor, {silent: true});
+                    element.set('lineColor', lineColor, {delaySave: true});
                 }
                 if (setLineWidth) {
-                    element.set('lineWidth', lineWidth, {silent: true});
+                    element.set('lineWidth', lineWidth, {delaySave: true});
                 }
             });
             const annotationData = _.extend({}, this.annotation.get('annotation'));
             annotationData.elements = this.annotation.elements().toJSON();
-            this.annotation.set('annotation', annotationData, {silent: true});
+            this.annotation.set('annotation', annotationData, {delaySave: true});
         }
 
         const visible = this.$('#h-annotation-visible').prop('checked');

--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -441,7 +441,10 @@ var AnnotationSelector = Panel.extend({
         );
     },
 
-    _saveAnnotation(annotation) {
+    _saveAnnotation(annotation, options) {
+        if (options && options.delaySave) {
+            return;
+        }
         if (this.viewer && !this.viewer._saving) {
             this.viewer._saving = {};
         }

--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -435,7 +435,7 @@ var DrawWidget = Panel.extend({
             }
             return result;
         }).filter((annot) => !annot.points || annot.points.length);
-        Object.keys(oldids).forEach((id) => this.deleteElement(undefined, id, {silent: elements.length}));
+        Object.keys(oldids).forEach((id) => this.deleteElement(undefined, id, {delaySave: elements.length}));
         this.addElements(
             _.map(elements, (el) => {
                 el = _.extend(el, _.omit(this._style.toJSON(), 'id'));

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -1592,12 +1592,11 @@ var ImageView = View.extend({
         const groupedAnnotations = this.selectedElements.groupBy((element) => element.originalAnnotation.id);
         _.each(groupedAnnotations, (elements, annotationId) => {
             const annotation = this.annotations.get(annotationId);
-            _.each(elements, (element) => { /* eslint-disable backbone/no-silent */
+            _.each(elements, (element) => {
                 const annotationElement = annotation.elements().get(element.id);
-                // silence the event because we want to make one save call for each annotation.
-                annotationElement.set(element.toJSON(), {silent: true});
+                annotationElement.set(element.toJSON(), {delaySave: true});
                 if (!element.get('group')) {
-                    annotationElement.unset('group', {silent: true});
+                    annotationElement.unset('group', {delaySave: true});
                 }
             });
             if (!elements.length) {
@@ -1613,7 +1612,7 @@ var ImageView = View.extend({
         _.each(groupedAnnotations, (elements, annotationId) => { /* eslint-disable backbone/no-silent */
             // silence the event because we want to make one save call for each annotation.
             const elementsCollection = this.annotations.get(annotationId).elements();
-            elementsCollection.remove(elements, {silent: true});
+            elementsCollection.remove(elements, {delaySave: true});
             elementsCollection.trigger('reset', elementsCollection);
         });
     },

--- a/histomicsui/web_client/views/popover/AnnotationContextMenu.js
+++ b/histomicsui/web_client/views/popover/AnnotationContextMenu.js
@@ -68,7 +68,7 @@ const AnnotationContextMenu = View.extend({
             }
         });
         let refresh = false;
-        this.collection.each((element) => { /* eslint-disable backbone/no-silent */
+        this.collection.each((element) => {
             if (this.parentView.drawWidget && this.parentView.activeAnnotation.id === element.originalAnnotation.id &&
                     element.attributes.group !== group && ['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(element.attributes.type)) {
                 this.parentView.drawWidget.updateCount(element.attributes.group || this.parentView._defaultGroup, -1);
@@ -78,9 +78,9 @@ const AnnotationContextMenu = View.extend({
             if (group) {
                 styleAttrs.group = group;
             } else {
-                element.unset('group', {silent: true});
+                element.unset('group', {delaySave: true});
             }
-            element.set(styleAttrs, {silent: true});
+            element.set(styleAttrs, {delaySave: true});
         });
         this.collection.trigger('h:save');
         this.trigger('h:close');


### PR DESCRIPTION
We really should never use silent.  This removes its use in annotation elements.