### PR TITLE
For some paged annotations, reduce some unncessaray redraws

### DIFF
--- a/histomicsui/web_client/panels/AnnotationSelector.js
+++ b/histomicsui/web_client/panels/AnnotationSelector.js
@@ -440,6 +440,9 @@ var AnnotationSelector = Panel.extend({
         if (options && options.delaySave) {
             return;
         }
+        if (annotation._fromFetch) {
+            return;
+        }
         if (this.viewer && !this.viewer._saving) {
             this.viewer._saving = {};
         }


### PR DESCRIPTION
When a paged annotation fetches a page, there were times we would render the paged data twice.