### PR TITLE
Speed up bulk setting style groups

### DIFF
--- a/histomicsui/web_client/panels/DrawWidget.js
+++ b/histomicsui/web_client/panels/DrawWidget.js
@@ -101,10 +101,14 @@ var DrawWidget = Panel.extend({
         }
         const name = (this.annotation.get('annotation') || {}).name || 'Untitled';
         if (!updatedElement || (updatedElement.attributes && updatedElement.get('type') !== 'pixelmap')) {
-            this.trigger('h:redraw', this.annotation);
+            if (this.annotationSelector) {
+                this.annotationSelector._debounceTriggerRedraw(this.annotation);
+            }
         }
         if (this._skipRenderHTML) {
-            delete this._skipRenderHTML;
+            if (this._skipRenderHTML !== 'skip') {
+                delete this._skipRenderHTML;
+            }
         } else {
             this.$el.html(drawWidget({
                 title: 'Draw',
@@ -243,7 +247,7 @@ var DrawWidget = Panel.extend({
                     this.updateCount(group || this.parentView._defaultGroup, 1);
                 }
             }
-            this._skipRenderHTML = true;
+            this._skipRenderHTML = this._skipRenderHTML || true;
         });
     },
 
@@ -312,7 +316,7 @@ var DrawWidget = Panel.extend({
             interp: distance < 500 ? undefined : window.d3.interpolateZoom,
             ease: window.d3.easeExpInOut
         });
-        this._skipRenderHTML = true;
+        this._skipRenderHTML = this._skipRenderHTML || true;
     },
 
     /**
@@ -329,7 +333,7 @@ var DrawWidget = Panel.extend({
             this.countPixelmap(this.collection.get(id), -1);
         }
         this.$(`.h-element[data-id="${id}"]`).remove();
-        this._skipRenderHTML = true;
+        this._skipRenderHTML = this._skipRenderHTML || true;
         this.collection.remove(id, opts);
         this.newElementDisplayIdStart = +(this.$el.find('.h-element>span.h-element-label[display_id]').last().attr('display_id') || 0);
     },
@@ -341,7 +345,7 @@ var DrawWidget = Panel.extend({
      *    collection.
      */
     addElements(elements) {
-        this._skipRenderHTML = true;
+        this._skipRenderHTML = this._skipRenderHTML || true;
         elements = this.collection.add(elements);
         this.$el.find('.h-elements-container').append(
             drawWidgetElement({

--- a/histomicsui/web_client/views/popover/AnnotationContextMenu.js
+++ b/histomicsui/web_client/views/popover/AnnotationContextMenu.js
@@ -68,6 +68,9 @@ const AnnotationContextMenu = View.extend({
             }
         });
         let refresh = false;
+        if (this.parentView.drawWidget) {
+            this.parentView.drawWidget._skipRenderHTML = 'skip';
+        }
         this.collection.each((element) => {
             if (this.parentView.drawWidget && this.parentView.activeAnnotation.id === element.originalAnnotation.id &&
                     element.attributes.group !== group && ['point', 'polyline', 'rectangle', 'ellipse', 'circle'].includes(element.attributes.type)) {
@@ -84,6 +87,9 @@ const AnnotationContextMenu = View.extend({
         });
         this.collection.trigger('h:save');
         this.trigger('h:close');
+        if (this.parentView.drawWidget) {
+            delete this.parentView.drawWidget._skipRenderHTML;
+        }
         if (this.parentView.drawWidget && refresh) {
             this.parentView.drawWidget.render();
         }


### PR DESCRIPTION
When setting the group from the context menu on a large number of annotation elements, we were refreshing the draw widget once per element instead of once at the end.