### PR TITLE
Add annotation legends

### DIFF
--- a/histomicsui/web_client/stylesheets/panels/annotationSelector.styl
+++ b/histomicsui/web_client/stylesheets/panels/annotationSelector.styl
@@ -53,11 +53,26 @@
   border-width 0
   white-space nowrap
   overflow hidden
+  display flex
+  gap 6px
 
   i
     margin-right 2px
     float left
     color #6b6b6b
+
+  .h-annotation-group-text
+    flex 1 1 auto
+    overflow hidden
+    white-space nowrap
+    min-width 0
+
+  .h-annotation-group-legend
+    width 18px
+    height 18px
+    border solid #0000
+    backrground #0000
+    flex-shrink 0
 
   &:hover
     background-color #eee

--- a/histomicsui/web_client/stylesheets/panels/drawWidget.styl
+++ b/histomicsui/web_client/stylesheets/panels/drawWidget.styl
@@ -53,27 +53,49 @@
     border-width 1px 0
     border-style solid
     border-color #bababa
-    padding 5px 4px 0 3px
-    margin 5px 5px 0
-    width fit-content
-    max-width calc(100% - 10px)
+    padding 5px 0 0
+    margin 0
+    display flex
+    flex-direction row
 
     .h-group-count-label
-      display inline-block
       vertical-align top
+      flex-shrink 0
 
     .h-group-count-options
-      display inline-block
       padding-left 5px
-      max-width 200px
+      flex-shrink 1
+      flex-grow 1
+      display flex
+      flex-direction column
+      overflow hidden
 
       .h-group-count-option
         white-space nowrap
         overflow hidden
         text-overflow ellipsis
+        flex-shrink 1
+        display flex
 
-    .h-group-count-select
-      padding-left 10px
+        .h-group-count-value
+          flex-shrink 1
+          text-overflow ellipsis
+          overflow hidden
+          min-width 0
+
+        .h-group-count-legend
+          width 16px
+          height 16px
+          vertical-align middle
+          flex-shrink 0
+          padding-left 4px
+          border solid #0000
+          margin-top 2px
+          margin-left auto
+
+      .h-group-count-select
+        flex-shrink 0
+        padding-left 6px
 
   .btn-default.active
     background-color #5790ff

--- a/histomicsui/web_client/templates/panels/annotationSelector.pug
+++ b/histomicsui/web_client/templates/panels/annotationSelector.pug
@@ -24,16 +24,40 @@ block content
   - var groups = _.keys(annotationGroups);
   - groups.sort();
   each groupName in groups
-    - var annotations = annotationGroups[groupName];
-    - var expanded = expandedGroups.has(groupName);
-    - var expandedClass = expanded ? 'h-group-expanded' : 'h-group-collapsed';
+    -
+      var annotations = annotationGroups[groupName];
+      var expanded = expandedGroups.has(groupName);
+      var expandedClass = expanded ? 'h-group-expanded' : 'h-group-collapsed';
+      var samplestyle={};
+      annotations.some((a) => {
+        var elems = (a.get('annotation') || {}).elements;
+        if (!elems) {
+          return false;
+        }
+        return elems.some((e) => {
+          if (e.group === groupName) {
+            if (e.fillColor) {
+              samplestyle.background = e.fillColor;
+            }
+            if (e.lineColor) {
+              samplestyle['border-color'] = e.lineColor;
+            }
+            if (e.lineWidth) {
+              samplestyle['border-width'] = e.lineWidth + 'px';
+            }
+            return samplestyle.background && samplestyle['border-color'] && samplestyle['border-width'];
+          }
+        });
+      })
     .h-annotation-group(class=[expandedClass], data-group-name=groupName)
-      .h-annotation-group-name.clearfix
+      .h-annotation-group-name
         if expanded
           i.icon-folder-open
         else
           i.icon-folder
-        = groupName
+        .h-annotation-group-text
+          = groupName
+        span.h-annotation-group-legend(style=samplestyle)
       if expanded
         each annotation in annotations
           - var name = annotation.get('annotation').name;

--- a/histomicsui/web_client/templates/panels/drawWidgetElement.pug
+++ b/histomicsui/web_client/templates/panels/drawWidgetElement.pug
@@ -1,13 +1,18 @@
-- var counts = {};
-- var displayIdOffset = 0;
-- var pixelmap = false;
-- var typeCounts = {};
+-
+  var counts = {};
+  var displayIdOffset = 0;
+  var pixelmap = false;
+  var typeCounts = {};
+  var groupStyles = {};
 if elements.length
   each element in elements
     -
       var classes = highlighted[element.id] ? ['h-highlight-element'] : [];
       element = element.toJSON();
       var groupName = element['group'] ? element['group'] : defaultGroup;
+      if (!groupStyles[groupName]) {
+        groupStyles[groupName] = {};
+      }
       var type = element.type === 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type;
       var displayId = ++displayIdOffset + displayIdStart;
       var label = ((element.label || {}).value || type);
@@ -36,6 +41,15 @@ if elements.length
       if (element.type === 'pixelmap') {
         pixelmap = true;
       }
+      if (!groupStyles[groupName]['background-color'] && element['fillColor']) {
+        groupStyles[groupName]['background-color'] = element['fillColor'];
+      }
+      if (!groupStyles[groupName]['border-color'] && element['lineColor']) {
+        groupStyles[groupName]['border-color'] = element['lineColor'];
+      }
+      if (!groupStyles[groupName]['border-width'] && element['lineWidth']) {
+        groupStyles[groupName]['border-width'] = element['lineWidth'] + 'px';
+      }
     .h-element(data-id=element.id, class=classes)
       span.icon-cog.h-edit-element(title='Change style')
       span.h-element-label(title=label, display_id=displayId) #{label}
@@ -58,6 +72,7 @@ if firstRender
     .h-group-count-option(data-group=group[0], data-count=group[1])
       span.h-group-count-value #{group[1]} #{group[0]}
       span.icon-marquee.h-group-count-select(title="Select all elements in this group")
+      span.h-group-count-legend(style=groupStyles[group[0]])
 else
   - for (let group in counts)
     - updateCount(group, counts[group]);


### PR DESCRIPTION
When annotations have been loaded enough, the first element that has fill color, line color, or line width information is used to show the style of that group.  For individual annotations, this is also shown with the group counts.  As part of this, the count area has been refactored slightly to prevent long group names from making the marquee selector tool from becoming unreachable.