### PR TITLE
Drop Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,6 @@ commands:
           command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; ./codecov --disable search pycov gcov --file .tox/coverage/py_coverage.xml,.tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
 
 jobs:
-  py39:
-    executor: toxandnode
-    steps:
-      - checkout
-      - tox:
-          env: py39
-      - coverage
   py310:
     executor: toxandnode
     steps:
@@ -101,13 +94,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - py39:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore:
-                - gh-pages
       - py310:
           filters:
             tags:
@@ -152,7 +138,6 @@ workflows:
                 - gh-pages
       - release:
           requires:
-            - py39
             - py310
             - py311
             - py312

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
   hooks:
     - id: pyupgrade
       args:
-        - --py39-plus
+        - --py310-plus
         - --keep-percent-format
 - repo: https://github.com/pre-commit/mirrors-autopep8
   rev: v2.0.4

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -58,7 +57,7 @@ setup(
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/DigitalSlideArchive/histomicsui',
     zip_safe=False,
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     entry_points={
         'girder.plugin': [
             'histomicsui = histomicsui:GirderPlugin',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{38,39,310,311,312,313}
+  py{310,311,312,313}
   lint
   lintclient
 


### PR DESCRIPTION
It is EOL in a few weeks and is getting harder to test with pkg_resources deprecation.