### PR TITLE
Prevent Group Settings Form Reset

### DIFF
--- a/histomicsui/web_client/dialogs/editStyleGroups.js
+++ b/histomicsui/web_client/dialogs/editStyleGroups.js
@@ -28,8 +28,9 @@ const EditStyleGroups = View.extend({
         'click #h-import-replace': '_toggleImportReplace',
         'change #h-import-groups': '_importGroups',
         'change .h-style-def': '_updateStyle',
+        'change #h-element-fill-pattern': '_updateStyle',
         'changeColor .h-colorpicker': '_updateStyle',
-        'change select': '_setStyle'
+        'change .h-group-name': '_setStyle'
     },
 
     render() {


### PR DESCRIPTION
Previously, changing the fill pattern reloaded the selected group's saved style and re-rendered the form. We now bind the fill pattern control to `_updateStyle()` so that only switching groups triggers a reset.

========== PREVIOUS BEHAVIOR ==========

[Screencast from 06-29-2026 03:26:49 PM.webm](https://github.com/user-attachments/assets/bcd47046-2bd0-4d11-8a99-ffe934c1328e)

========== NEW BEHAVIOR ==========

[Screencast from 06-29-2026 03:29:02 PM.webm](https://github.com/user-attachments/assets/8b807a5f-610b-4149-9054-44d1a9cf74bc)
