### PR TITLE
Use config file to set unselected annot opacity

### DIFF
--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -205,13 +205,17 @@ var ImageView = View.extend({
                 // it is very confusing if this value is smaller than the
                 // AnnotationSelector MAX_ELEMENTS_LIST_LENGTH
                 highlightFeatureSizeLimit: 5000,
-                scale: {position: {bottom: 20, right: 10}}
+                scale: {position: {bottom: 20, right: 10}},
+                unselectedOpacityMultiplier: typeof this._unselectedOpacityMultiplier !== 'number'
+                    ? 0.25
+                    : this._unselectedOpacityMultiplier
             });
             // Don't unclamp bounds for the image even if image overlays are present.
             if (this.viewerWidget.setUnclampBoundsForOverlay) {
                 this.viewerWidget.setUnclampBoundsForOverlay(false);
             }
             this.trigger('h:viewerWidgetCreated', this.viewerWidget);
+            this.viewerWidget.setUnselectedOpacityMultiplier(this._unselectedOpacityMultiplier);
 
             // handle annotation mouse events
             this.listenTo(this.viewerWidget, 'g:mouseOverAnnotation', this.mouseOverAnnotation);
@@ -1783,6 +1787,14 @@ var ImageView = View.extend({
                         groups.each((model) => { model.save(); });
                     }
                 });
+            }
+            if (val.unselectedOpacityMultiplier !== undefined) {
+                this._unselectedOpacityMultiplier = typeof val.unselectedOpacityMultiplier !== 'number'
+                    ? 0.25
+                    : val.unselectedOpacityMultiplier;
+                if (this.viewerWidget) {
+                    this.viewerWidget.setUnselectedOpacityMultiplier(val.unselectedOpacityMultiplier);
+                }
             }
         });
     },


### PR DESCRIPTION
Fix #541 

Previously, non-selected annotation elements had their opacity reduced by multiplying by `0.25`. This reduction was hard-coded behavior in the `girder_large_image_annotation` image viewer widget.

Accompanying changes to the `girder_large_image_annotation` plugin allow passing in a custom opacity multiplier.

The changes in this PR read a key/value pair with the key `unselectedOpacityMultiplier` from the `.histomicsui_config.yaml` item and pass that value to the image viewer widget.