### PR TITLE
Use config file to set unselected annot opacity

### DIFF
--- a/docs/config_options.rst
+++ b/docs/config_options.rst
@@ -79,6 +79,15 @@ If a hotkey is specified for a group, it will only be active if the group was lo
         action: group
         param: Red
 
+Unselected Annotation Capacity
+______________________________
+When annotation elements are selected, the annotations not included in the user's selection have their opacity decreased to 0.33 times their specified opacity. This can be modified:
+::
+    ---
+    # A lower value will make unselected annotations more transparent.
+    unselectedOpacityMultiplier: 0.33
+
+
 UI Settings
 ___________
 

--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -205,13 +205,17 @@ var ImageView = View.extend({
                 // it is very confusing if this value is smaller than the
                 // AnnotationSelector MAX_ELEMENTS_LIST_LENGTH
                 highlightFeatureSizeLimit: 5000,
-                scale: {position: {bottom: 20, right: 10}}
+                scale: {position: {bottom: 20, right: 10}},
+                unselectedOpacityMultiplier: typeof this._unselectedOpacityMultiplier !== 'number'
+                    ? 0.33
+                    : this._unselectedOpacityMultiplier
             });
             // Don't unclamp bounds for the image even if image overlays are present.
             if (this.viewerWidget.setUnclampBoundsForOverlay) {
                 this.viewerWidget.setUnclampBoundsForOverlay(false);
             }
             this.trigger('h:viewerWidgetCreated', this.viewerWidget);
+            this.viewerWidget.setUnselectedOpacityMultiplier(this._unselectedOpacityMultiplier);
 
             // handle annotation mouse events
             this.listenTo(this.viewerWidget, 'g:mouseOverAnnotation', this.mouseOverAnnotation);
@@ -1783,6 +1787,14 @@ var ImageView = View.extend({
                         groups.each((model) => { model.save(); });
                     }
                 });
+            }
+            if (val.unselectedOpacityMultiplier !== undefined) {
+                this._unselectedOpacityMultiplier = typeof val.unselectedOpacityMultiplier !== 'number'
+                    ? 0.33
+                    : val.unselectedOpacityMultiplier;
+                if (this.viewerWidget) {
+                    this.viewerWidget.setUnselectedOpacityMultiplier(val.unselectedOpacityMultiplier);
+                }
             }
         });
     },

--- a/tests/test_files/.histomicsui_config.yaml
+++ b/tests/test_files/.histomicsui_config.yaml
@@ -1,4 +1,5 @@
 ---
+unselectedOpacityMultiplier: 0.5
 annotationGroups:
   # If replaceGroups isn't present or false, groups will be merged with
   # existing groups.  Those that have the same name will be updated.  If

--- a/tests/web_client_specs/annotationSpec.js
+++ b/tests/web_client_specs/annotationSpec.js
@@ -1812,6 +1812,11 @@ girderTest.promise.done(function () {
         it('open image', function () {
             huiTest.openImage('image.svs', ['subfolder']);
         });
+        it('respects unselected opacity config', function () {
+            girderTest.waitForLoad();
+            expect(huiTest.app.bodyView._unselectedOpacityMultiplier).toBe(0.5);
+            expect(huiTest.app.bodyView.viewerWidget._unselectedOpacityMultiplier).toBe(0.5);
+        });
         it('create a new annotation', function () {
             girderTest.waitForLoad();
             runs(function () {


### PR DESCRIPTION
Fix https://github.com/DigitalSlideArchive/HistomicsUI/issues/541

Previously, non-selected annotation elements had their opacity reduced by multiplying by `0.25`. This reduction was hard-coded behavior in the `girder_large_image_annotation` image viewer widget.

Accompanying changes to the `girder_large_image_annotation` plugin allow passing in a custom opacity multiplier.

The changes in this PR read a key/value pair with the key `unselectedOpacityMultiplier` from the `.histomicsui_config.yaml` item and pass that value to the image viewer widget.