### PR TITLE
Notify open views when config-loaded style groups change

### DIFF
--- a/histomicsui/web_client/views/body/ImageView.js
+++ b/histomicsui/web_client/views/body/ImageView.js
@@ -1788,7 +1788,13 @@ var ImageView = View.extend({
                             group.label = group.label ? {value: group.label} : undefined;
                             groups.add(group);
                         });
-                        groups.each((model) => { model.save(); });
+                        const saves = groups.map((model) => model.save());
+                        // Other views (e.g. the annotation context menu) may have already
+                        // fetched their own style collection from localStorage before this
+                        // config finished loading; let them know to refetch now that it has.
+                        $.when(...saves).done(() => {
+                            this.trigger('h:styleGroupsEdited', groups);
+                        });
                     }
                 });
             }


### PR DESCRIPTION
The context menu fetches its style groups eagerly in `initialize()`, before `_getConfig`'s network request resolves, so it could end up showing stale groups from a previously viewed folder until the page was reloaded.

Fix `_getConfig` to trigger `'h:styleGroupsEdited'` once the new groups are saved, matching the pattern `DrawWidget` uses when groups are edited.